### PR TITLE
Fix mac1 offset in rate limiter

### DIFF
--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -167,7 +167,7 @@ impl RateLimiter {
     }
 
     /// Verify the MAC fields on the handshake, and apply rate limiting if needed.
-    fn verify_handshake<P: WgHandshakeBase>(
+    pub(crate) fn verify_handshake<P: WgHandshakeBase>(
         &self,
         src_addr: Option<IpAddr>,
         handshake: Packet<P>,


### PR DESCRIPTION
Handshake initiations are currently rejected because the MAC is calculated incorrectly