### PR TITLE
Add support for mimalloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Enable doc_cfg feature for docs.rs.
   https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html
+- Add `mimalloc` as an optional, alternative memory allocator.
 
 
 ## [0.6.0] - 2026-04-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "eyre",
  "gotatun",
  "libc",
+ "mimalloc",
  "nix",
  "tokio",
  "tracing",
@@ -1138,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ ipnetwork = "0.21.1"
 libc = "0.2.180"
 log = "0.4.29"
 maybenot = "2.2.2"
+mimalloc = { version = "0.1", default-features = false }
 mock_instant = "0.6"
 nix = { version = "0.31", default-features = false }
 parking_lot = "0.12.5"

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["command-line-utilities", "network-programming"]
 name = "gotatun"
 path = "src/main.rs"
 
+[dependencies]
+mimalloc = { workspace = true, default-features = false, optional = true }
+
 [target.'cfg(unix)'.dependencies]
 clap = { workspace = true, features = ["derive", "env"] }
 daemonize = { workspace = true }
@@ -45,8 +48,10 @@ tracing-subscriber = { workspace = true }
 
 [features]
 default = ["aws-lc-rs"]
+# Use the `aws-lc-rs` crate as the AEAD backend. Default.
+aws-lc-rs = ["gotatun/aws-lc-rs"]
+# Use mimalloc as allocator instead of system default.
+mimalloc = ["dep:mimalloc"]
 # Use the `ring` crate as the AEAD backend. Combine with
 # `--no-default-features` to avoid also pulling in `aws-lc-rs`.
 ring = ["gotatun/ring"]
-# Use the `aws-lc-rs` crate as the AEAD backend. Default.
-aws-lc-rs = ["gotatun/aws-lc-rs"]

--- a/gotatun-cli/README.md
+++ b/gotatun-cli/README.md
@@ -1,0 +1,9 @@
+# GotaTun
+
+## Memory allocation
+`gotatun` uses the [system]'s default allocator by default, but other allocators may be enabled via features:
+
+- `mimalloc`: Uses [mi-malloc] as the global memory allocator.
+
+[system]: https://doc.rust-lang.org/std/alloc/struct.System.html
+[mi-malloc]: https://microsoft.github.io/mimalloc/

--- a/gotatun-cli/src/allocator/mod.rs
+++ b/gotatun-cli/src/allocator/mod.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/gotatun-cli/src/main.rs
+++ b/gotatun-cli/src/main.rs
@@ -11,6 +11,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Common imports that are used on both platforms
+#[cfg(feature = "mimalloc")]
+mod allocator;
 
 // Unix implementation
 #[cfg(unix)]


### PR DESCRIPTION
This PR adds [mi-malloc](https://microsoft.github.io/mimalloc/) as an alternative memory allocator to libc. This is exposed via the new `mimalloc` feature flag in the  `gotatun-cli` crate.

I've not played around too much with it yet, but adding the initial infrastructure for experimenting with different memory allocators proved to be rather straightforward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/27)
<!-- Reviewable:end -->
