### PR TITLE
Fix tunnel stats not accounting for handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ring` can opt in by building with `--no-default-features --features ring`.
 - Make the `ring` dependency optional, gated behind the new `ring` feature.
 
+### Fixed
+- Make tunnel stats counters more consistent with other WG implementations.
+
 ### Security
 - Include source port in cookie MAC input. The WireGuard whitepaper states that the cookie
   should be computed using the remote endpoint's address, being both the IP and port.

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -548,6 +548,7 @@ impl<T: DeviceTransports> DeviceState<T> {
             let parsed_packet = match rate_limiter.verify_packet(addr, src_buf) {
                 Ok(packet) => packet,
                 Err(TunnResult::WriteToNetwork(WgKind::CookieReply(cookie))) => {
+                    // Note: Cookies should not affect counters.
                     if let Err(_err) = udp_tx.send_to(cookie.into(), addr).await {
                         log::trace!("udp.send_to failed");
                         break;

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -230,7 +230,9 @@ impl<R: RngCore + Send> Tunn<R> {
     ) -> Result<TunnResult, WireGuardError> {
         log::debug!("Received handshake_initiation: {}", p.sender_idx);
 
+        let n_bytes = p.as_bytes().len();
         let (packet, session) = self.handshake.receive_handshake_initialization(p)?;
+        self.rx_bytes += n_bytes;
 
         // Store new session in next slot
         let slot = self.next_session_slot();
@@ -240,7 +242,7 @@ impl<R: RngCore + Send> Tunn<R> {
         self.timer_tick(TimerName::TimeLastPacketSent);
         self.timer_tick_session_established(false, slot); // New session established, we are not the initiator
 
-        log::debug!("Sending handshake_response: {slot}");
+        self.tx_bytes += packet.as_bytes().len();
 
         Ok(TunnResult::WriteToNetwork(packet.into()))
     }
@@ -256,6 +258,7 @@ impl<R: RngCore + Send> Tunn<R> {
         );
 
         let session = self.handshake.receive_handshake_response(&p)?;
+        self.rx_bytes += p.as_bytes().len();
 
         let mut p = p.into_bytes();
         p.truncate(0);
@@ -270,6 +273,7 @@ impl<R: RngCore + Send> Tunn<R> {
         self.set_current_session(slot);
 
         log::debug!("Sending keepalive");
+        self.tx_bytes += keepalive_packet.as_bytes().len();
 
         Ok(TunnResult::WriteToNetwork(keepalive_packet.into())) // Send a keepalive as a response
     }
@@ -321,7 +325,6 @@ impl<R: RngCore + Send> Tunn<R> {
         let decapsulated_packet = self.decapsulate_with_session(packet)?;
 
         self.timer_tick(TimerName::TimeLastDataPacketReceived);
-        self.rx_bytes += decapsulated_packet.as_bytes().len();
 
         Ok(TunnResult::WriteToTunnel(decapsulated_packet))
     }
@@ -355,6 +358,7 @@ impl<R: RngCore + Send> Tunn<R> {
         self.set_current_session(slot);
 
         self.timer_tick(TimerName::TimeLastPacketReceived);
+        self.rx_bytes += decapsulated_packet.as_bytes().len();
 
         Ok(decapsulated_packet)
     }
@@ -385,6 +389,9 @@ impl<R: RngCore + Send> Tunn<R> {
         }
         self.timer_tick(TimerName::TimeLastPacketSent);
         self.update_handshake_jitter();
+
+        self.tx_bytes += packet.as_bytes().len();
+
         Some(packet)
     }
 


### PR DESCRIPTION
The main difference I've seen compared to wireguard-go is that handshake initiations do not affect `tx_bytes`.

I've tried to make the behavior identical to that of wireguard-go. Any incoming packet that's accepted should contribute to `rx_bytes`, and any outbound packet on the UDP socket should contribute to `tx_bytes`. Except cookies. One difference is that wg-go adds `MinMessageSize` to incoming packet lengths (https://github.com/WireGuard/wireguard-go/blob/f333402bd9cbe0f3eeb02507bd14e23d7d639280/device/receive.go#L463).

Side-note: It might be more difficult than necessary to keep track of the side effects that different functions have on timers and counters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/68)
<!-- Reviewable:end -->
