### PR TITLE
Export maybenot as an optional dependency

### DIFF
--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -23,7 +23,7 @@ pcap = ["dep:pcap-file"]
 # UDP GRO appears to be broken on Windows.
 # In some cases it fails to return UDP_COALESCED_INFO
 windows-gro = []
-daita = []
+daita = ["device", "maybenot"]
 
 [dependencies]
 base64 = "0.13"
@@ -62,7 +62,7 @@ pcap-file = { version = "2.0.0", optional = true }
 duplicate = { version = "2.0.0", default-features = false }
 constant_time_eq = "0.4.2"
 futures = "0.3.31"
-maybenot = "2.2.2"
+maybenot = { version = "2.2.2", optional = true }
 rand_chacha = "0.9.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/gotatun/src/device/daita/mod.rs
+++ b/gotatun/src/device/daita/mod.rs
@@ -14,9 +14,8 @@ mod types;
 use std::str::FromStr;
 
 pub use hooks::DaitaHooks;
-pub use maybenot;
 pub use maybenot::Error;
-pub use maybenot::Machine;
+use maybenot::Machine;
 
 pub mod api {
     #[derive(Debug, Clone)]

--- a/gotatun/src/lib.rs
+++ b/gotatun/src/lib.rs
@@ -29,3 +29,7 @@ pub mod x25519 {
         EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret,
     };
 }
+
+// Re-export of the maybenot types
+#[cfg(feature = "maybenot")]
+pub use maybenot;


### PR DESCRIPTION
This allows e.g. `talpid-tunnel-config-client` to import maybenot through `gotatun` to parse the machine strings, without having depend on the `device` or `daita` feature.

This also makes `daita` imply `device`, which was always a requirement. Building with `--features daita` previously did not work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/73)
<!-- Reviewable:end -->
