### PR TITLE
Include source port in cookie MAC input (fixes weakened DoS mitigation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ring` can opt in by building with `--no-default-features --features ring`.
 - Make the `ring` dependency optional, gated behind the new `ring` feature.
 
+### Security
+- Include source port in cookie MAC input. The WireGuard whitepaper states that the cookie
+  should be computed using the remote endpoint's address, being both the IP and port.
+  But the cookie was only using the sender's IP address. This weakened the built in DoS
+  mitigation by allowing for example multiple clients behind NAT to reuse a cookie issued
+  to a different source port.
+
 
 ## [0.5.1] - 2026-04-02
 ### Fixed

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -545,7 +545,7 @@ impl<T: DeviceTransports> DeviceState<T> {
         };
 
         while let Ok((src_buf, addr)) = udp_rx.recv_from(&mut packet_pool).await {
-            let parsed_packet = match rate_limiter.verify_packet(addr.ip(), src_buf) {
+            let parsed_packet = match rate_limiter.verify_packet(addr, src_buf) {
                 Ok(packet) => packet,
                 Err(TunnResult::WriteToNetwork(WgKind::CookieReply(cookie))) => {
                     if let Err(_err) = udp_tx.send_to(cookie.into(), addr).await {

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -927,8 +927,10 @@ mod tests {
     fn per_ip_rate_limiting_isolation() {
         let (mut my_tun, their_tun) = create_two_tuns();
 
-        let attacker_ip = Ipv4Addr::new(10, 0, 0, 1);
-        let legit_ip = Ipv4Addr::new(10, 0, 0, 2);
+        // Same port on both endpoints so the IP is the only varying factor.
+        const PORT: u16 = 51820;
+        let attacker = SocketAddr::new(Ipv4Addr::new(10, 0, 0, 1).into(), PORT);
+        let legit = SocketAddr::new(Ipv4Addr::new(10, 0, 0, 2).into(), PORT);
 
         // Exhaust the rate limit for the attacker IP
         for _ in 0..HANDSHAKE_RATE_LIMIT {
@@ -937,7 +939,7 @@ mod tests {
                 .expect("expected handshake init");
             their_tun
                 .rate_limiter
-                .verify_handshake(attacker_ip.into(), init)
+                .verify_handshake(attacker, init)
                 .expect("should be under limit");
             MockClock::advance(Duration::from_micros(1));
         }
@@ -948,9 +950,7 @@ mod tests {
             .expect("expected handshake init");
         assert!(
             matches!(
-                their_tun
-                    .rate_limiter
-                    .verify_handshake(attacker_ip.into(), init),
+                their_tun.rate_limiter.verify_handshake(attacker, init),
                 Err(TunnResult::WriteToNetwork(WgKind::CookieReply(_)))
             ),
             "attacker IP should be rate limited"
@@ -962,7 +962,7 @@ mod tests {
             .expect("expected handshake init");
         their_tun
             .rate_limiter
-            .verify_handshake(legit_ip.into(), init)
+            .verify_handshake(legit, init)
             .expect("legitimate IP should not be rate limited");
     }
 

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -498,7 +498,7 @@ fn pad_to_x16(mut packet: Packet, tun_mtu: &mut MtuWatcher) -> Packet {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[cfg(feature = "mock_instant")]
     use crate::noise::timers::{MAX_JITTER, REKEY_AFTER_TIME, REKEY_TIMEOUT, TimerName};
@@ -641,12 +641,12 @@ mod tests {
 
         their_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), init)
+            .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), init)
             .expect("Handshake init to be valid");
 
         my_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), resp)
+            .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), resp)
             .expect("Handshake response to be valid");
     }
 
@@ -666,7 +666,7 @@ mod tests {
             let init = forced_handshake_init(&mut my_tun);
             their_tun
                 .rate_limiter
-                .verify_handshake(Ipv4Addr::LOCALHOST.into(), init)
+                .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), init)
                 .expect("Handshake init to be valid");
 
             MockClock::advance(Duration::from_micros(1));
@@ -676,7 +676,7 @@ mod tests {
         let init = forced_handshake_init(&mut my_tun);
         let Err(TunnResult::WriteToNetwork(WgKind::CookieReply(cookie_resp))) = their_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), init)
+            .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), init)
         else {
             panic!("expected cookie reply due to rate limiting");
         };
@@ -690,7 +690,7 @@ mod tests {
         let init = forced_handshake_init(&mut my_tun);
         their_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), init)
+            .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), init)
             .expect("should accept handshake with cookie");
     }
 
@@ -706,13 +706,16 @@ mod tests {
 
         their_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), init.clone())
+            .verify_handshake(
+                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345),
+                init.clone(),
+            )
             .map(|packet| packet.mac1)
             .expect_err("Handshake init to be invalid");
 
         my_tun
             .rate_limiter
-            .verify_handshake(Ipv4Addr::LOCALHOST.into(), resp)
+            .verify_handshake(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12345), resp)
             .map(|packet| packet.mac1)
             .expect_err("Handshake response to be invalid");
     }

--- a/gotatun/src/noise/rate_limiter.rs
+++ b/gotatun/src/noise/rate_limiter.rs
@@ -20,7 +20,7 @@ use constant_time_eq::constant_time_eq;
 use mock_instant::thread_local::Instant;
 use rand::TryRngCore;
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -112,17 +112,18 @@ impl RateLimiter {
         }
     }
 
-    /// Compute the correct cookie value based on the current secret value and the source IP
-    fn current_cookie(&self, addr: IpAddr) -> Cookie {
-        let mut addr_bytes = [0u8; 16];
+    /// Compute the correct cookie value based on the current secret value and the source address
+    fn current_cookie(&self, addr: SocketAddr) -> Cookie {
+        let mut addr_bytes = [0u8; 18]; // 16 for IP + 2 for port
 
-        match addr {
-            IpAddr::V4(a) => addr_bytes[..4].copy_from_slice(&a.octets()[..]),
-            IpAddr::V6(a) => addr_bytes[..].copy_from_slice(&a.octets()[..]),
+        match addr.ip() {
+            IpAddr::V4(a) => addr_bytes[..4].copy_from_slice(&a.octets()),
+            IpAddr::V6(a) => addr_bytes[..16].copy_from_slice(&a.octets()),
         }
+        addr_bytes[16..18].copy_from_slice(&addr.port().to_be_bytes());
 
         // The current cookie for a given IP is the MAC(responder.changing_secret_every_two_minutes,
-        // initiator.ip_address) First we derive the secret from the current time, the value
+        // initiator.address) First we derive the secret from the current time, the value
         // of cur_counter would change with time.
         let cur_counter = Instant::now().duration_since(self.start_time).as_secs() / COOKIE_REFRESH;
 
@@ -176,7 +177,11 @@ impl RateLimiter {
 
     /// Decode the packet as wireguard packet.
     /// Then, verify the MAC fields on the packet (if any), and apply rate limiting if needed.
-    pub fn verify_packet(&self, src_addr: IpAddr, packet: Packet) -> Result<WgKind, TunnResult> {
+    pub fn verify_packet(
+        &self,
+        src_addr: SocketAddr,
+        packet: Packet,
+    ) -> Result<WgKind, TunnResult> {
         let packet = packet
             .try_into_wg()
             .map_err(|_err| TunnResult::Err(WireGuardError::InvalidPacket))?;
@@ -196,7 +201,7 @@ impl RateLimiter {
     /// Verify the MAC fields on the handshake, and apply rate limiting if needed.
     pub(crate) fn verify_handshake<P: WgHandshakeBase>(
         &self,
-        src_addr: IpAddr,
+        src_addr: SocketAddr,
         handshake: Packet<P>,
     ) -> Result<Packet<P>, TunnResult> {
         let sender_idx = handshake.sender_idx();
@@ -208,7 +213,7 @@ impl RateLimiter {
             return Err(TunnResult::Err(WireGuardError::InvalidMac));
         }
 
-        if self.is_under_load(src_addr) {
+        if self.is_under_load(src_addr.ip()) {
             let cookie = self.current_cookie(src_addr);
             let computed_mac2 = b2s_keyed_mac_16_2(&cookie, handshake.until_mac1(), mac1);
 


### PR DESCRIPTION
The WireGuard protocol whitepaper (section 5.4.7) defines the cookie as Mac(Rm, Addr) where Addr is the remote endpoint's IP and port. Our implementation only used the IP address, allowing any endpoint behind the same IP (e.g. different clients behind NAT) to reuse a cookie issued to a different source port. This weakens the DoS mitigation since the cookie is meant to prove ownership of a specific endpoint.

Both the Linux kernel implementation and wireguard-go include the port in the MAC input.

This commit aligns our implementation with the spec and reference implementations by changing the cookie and verification functions to operate on SocketAddr instead of IpAddr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/96)
<!-- Reviewable:end -->
