### PR TITLE
Replace `tokio` `"full"` feature with specific features in use.

### DIFF
--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -60,7 +60,7 @@ rand_core = { workspace = true, features = ["getrandom"] }
 ring = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 thiserror = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net"] }
 tun = { workspace = true, default-features = false, features = ["async"], optional = true }
 typed-builder = { workspace = true }
 x25519-dalek = { workspace = true, features = [


### PR DESCRIPTION
This is for #116.

So, turns out, I was wrong about the precise feature set here.
You're also using `"net"`, but only inside of that native socket implementation module I mentioned
`cfg`-ing out. You can guess why I didn't notice when I opened my issue today!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/117)
<!-- Reviewable:end -->
