### PR TITLE
Add Windows CLI support for gotatun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is the new default. `aws-lc-rs` wins if both features are enabled, and
   then `ring` is built and linked for nothing.
 
+#### Windows
+- Add support for GotaTun CLI on Windows
+
 ### Changed
 - The default AEAD backend is now `aws-lc-rs`. Consumers that still want
   `ring` can opt in by building with `--no-default-features --features ring`.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Target triple                 |Binary|Library|
 x86_64-unknown-linux-gnu      |  ✓   | ✓    |
 aarch64-unknown-linux-gnu     |  ✓   | ✓    |
 aarch64-apple-darwin          |  ✓   | ✓    |
-x86_64-pc-windows-msvc        |      | ✓    |
-x86_64-pc-windows-gnullvm     |      | ✓    |
-aarch64-pc-windows-msvc       |      | ✓    |
-aarch64-pc-windows-gnullvm    |      | ✓    |
+x86_64-pc-windows-msvc        |  ✓   | ✓    |
+x86_64-pc-windows-gnullvm     |  ✓   | ✓    |
+aarch64-pc-windows-msvc       |  ✓   | ✓    |
+aarch64-pc-windows-gnullvm    |  ✓   | ✓    |
 x86_64-linux-android          |      | ✓    |
 aarch64-linux-android         |      | ✓    |
 aarch64-apple-ios             |      | ✓    |

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -34,6 +34,15 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+clap = { workspace = true, features = ["derive", "env"] }
+eyre = { workspace = true }
+gotatun = { workspace = true, features = ["device", "tun"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
+
 [features]
 default = ["aws-lc-rs"]
 # Use the `ring` crate as the AEAD backend. Combine with

--- a/gotatun-cli/src/main.rs
+++ b/gotatun-cli/src/main.rs
@@ -16,13 +16,21 @@
 #[cfg(unix)]
 mod unix;
 
+// Windows implementation
+#[cfg(windows)]
+mod windows;
+
 #[cfg(unix)]
 fn main() {
     unix::main();
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn main() {
-    // Empty main function for Windows
-    unimplemented!("GotaTun CLI is not supported on Windows");
+    windows::main();
+}
+
+#[cfg(not(any(unix, windows)))]
+fn main() {
+    unimplemented!("GotaTun CLI is not supported on this platform");
 }

--- a/gotatun-cli/src/windows/mod.rs
+++ b/gotatun-cli/src/windows/mod.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use clap::Parser;
+use eyre::{Context, Result};
+use gotatun::device::uapi::UapiServer;
+use gotatun::device::{DefaultDeviceTransports, Device, DeviceBuilder};
+use gotatun::tun::tun_async_device::TunDevice;
+use std::fs::File;
+use std::path::PathBuf;
+use std::process::exit;
+use tracing::{Level, info};
+
+/// GotaTun - A userspace WireGuard implementation
+#[derive(Parser)]
+#[clap(version, author = "Mullvad VPN <https://github.com/mullvad/gotatun>")]
+struct Args {
+    /// Interface name to use for the TUN interface
+    interface_name: String,
+
+    /// Log verbosity
+    #[clap(short, long, env = "WG_LOG_LEVEL", possible_values = ["error", "info", "debug", "trace"], default_value = "info")]
+    verbosity: Level,
+
+    /// Log file (default: stdout)
+    #[clap(short, long, env = "WG_LOG_FILE")]
+    log: Option<PathBuf>,
+
+    /// Path to wintun.dll. If omitted, wintun.dll is searched using the default DLL search order
+    /// (which includes the executable directory and PATH).
+    #[clap(long, env = "WINTUN_PATH")]
+    wintun: Option<PathBuf>,
+}
+
+pub fn main() {
+    if let Err(e) = run() {
+        eprintln!("GotaTun failed: {e:?}");
+        exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+    // Keep the logging guard alive for the duration of the program.
+    let _logging_guard = setup_logging(&args)?;
+    tokio::runtime::Runtime::new()
+        .context("Failed to create tokio runtime")?
+        .block_on(async {
+            let device = setup_device(&args)
+                .await
+                .context("Failed to start tunnel")?;
+            info!("GotaTun started successfully");
+            tokio::signal::ctrl_c()
+                .await
+                .context("Failed to listen for Ctrl+C")?;
+            info!("GotaTun is shutting down");
+            device.stop().await;
+            Ok(())
+        })
+}
+
+fn setup_logging(args: &Args) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
+    match &args.log {
+        Some(log_file) => {
+            let file = File::create(log_file)
+                .with_context(|| format!("Could not create log file {}", log_file.display()))?;
+            let (non_blocking, guard) = tracing_appender::non_blocking(file);
+            tracing_subscriber::fmt()
+                .with_max_level(args.verbosity)
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .init();
+            Ok(Some(guard))
+        }
+        None => {
+            tracing_subscriber::fmt()
+                .pretty()
+                .with_max_level(args.verbosity)
+                .init();
+            Ok(None)
+        }
+    }
+}
+
+/// Create and configure the WireGuard tunnel device.
+async fn setup_device(args: &Args) -> eyre::Result<Device<DefaultDeviceTransports>> {
+    let tun = match &args.wintun {
+        Some(wintun_path) => {
+            TunDevice::from_name_with_wintun_path(&args.interface_name, wintun_path)
+                .context("Failed to create TUN device")?
+        }
+        None => {
+            TunDevice::from_name(&args.interface_name).context("Failed to create TUN device")?
+        }
+    };
+
+    let tun_name = tun.name().context("Failed to get TUN device name")?;
+    info!("Tunnel interface: {tun_name}");
+
+    let uapi =
+        UapiServer::default_named_pipe(&tun_name).context("Failed to create UAPI named pipe")?;
+
+    let dev = DeviceBuilder::new()
+        .with_uapi(uapi)
+        .with_default_udp()
+        .with_ip(tun)
+        .build()
+        .await
+        .context("Failed to start WireGuard device")?;
+
+    Ok(dev)
+}

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -61,7 +61,7 @@ rand_core = { workspace = true, features = ["getrandom"] }
 ring = { workspace = true, optional = true }
 socket2 = { workspace = true, features = ["all"] }
 thiserror = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net", "io-util"] }
 tun = { workspace = true, default-features = false, features = ["async"], optional = true }
 typed-builder = { workspace = true }
 x25519-dalek = { workspace = true, features = [
@@ -83,7 +83,10 @@ windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Networking",
   "Win32_Networking_WinSock",
+  "Win32_Security",
+  "Win32_Security_Authorization",
   "Win32_System_IO",
+  "Win32_System_Threading",
 ] }
 
 [target.'cfg(unix)'.dependencies]

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -127,54 +127,7 @@ impl UapiClient {
         RW: Send + Sync + 'static,
     {
         std::thread::spawn(move || {
-            let r = BufReader::new(&rw);
-
-            let make_request = |s: &str| {
-                let request = Request::from_str(s).wrap_err("Failed to parse command")?;
-
-                let Some(response) = self.send_sync(request).ok() else {
-                    bail!("Server hung up");
-                };
-
-                if let Err(e) = writeln!(&rw, "{response}") {
-                    log::error!("Failed to write API response: {e}");
-                }
-
-                Ok(())
-            };
-
-            let mut lines = String::new();
-
-            for line in r.lines() {
-                let Ok(line) = line else {
-                    if !lines.is_empty()
-                        && let Err(e) = make_request(&lines)
-                    {
-                        log::error!("Failed to handle UAPI request: {e:#}");
-                        return;
-                    }
-                    return;
-                };
-
-                // Final line of a command is empty, so if this one is not, we add it to the
-                // `lines` buffer and wait for more.
-                if !line.is_empty() {
-                    lines.push_str(&line);
-                    lines.push('\n');
-                    continue;
-                }
-
-                if lines.is_empty() {
-                    continue;
-                }
-
-                if let Err(e) = make_request(&lines) {
-                    log::error!("Failed to handle UAPI request: {e:#}");
-                    return;
-                }
-
-                lines.clear();
-            }
+            run_uapi_protocol_sync(self, &rw, &rw);
         });
     }
 }
@@ -199,7 +152,7 @@ impl UapiServer {
         uid: Option<Uid>,
         gid: Option<Gid>,
     ) -> eyre::Result<Self> {
-        use std::os::unix::net::UnixListener;
+        use tokio::net::UnixListener;
 
         let path = format!("{SOCK_DIR}/{name}.sock");
 
@@ -219,21 +172,76 @@ impl UapiServer {
 
         let (tx, rx) = UapiServer::new();
 
-        std::thread::spawn(move || {
+        tokio::spawn(async move {
             loop {
-                let Ok((stream, _)) = api_listener.accept() else {
+                let Ok((stream, _)) = api_listener.accept().await else {
                     break;
                 };
 
                 log::info!("New UAPI connection on unix socket");
 
-                tx.clone().wrap_read_write(stream);
+                let client = tx.clone();
+                tokio::spawn(async move {
+                    let (r, w) = stream.into_split();
+                    run_uapi_protocol(client, r, w).await;
+                });
             }
         });
 
         Ok(rx)
+    }
 
-        //self.cleanup_paths.push(path.clone());
+    /// Spawn a named pipe server at `\\.\pipe\ProtectedPrefix\Administrators\WireGuard\<name>`. This pipe speaks the official
+    /// [configuration protocol](https://www.wireguard.com/xplatform/#configuration-protocol).
+    ///
+    /// This is the Windows equivalent of [`UapiServer::default_unix_socket`].
+    ///
+    /// Must be called from within a tokio runtime context.
+    #[cfg(windows)]
+    pub fn default_named_pipe(name: &str) -> eyre::Result<Self> {
+        let pipe_path = format!(r"\\.\pipe\ProtectedPrefix\Administrators\WireGuard\{name}");
+        let (tx, rx) = UapiServer::new();
+
+        // Enable SeRestorePrivilege so we can set the pipe owner to SYSTEM
+        // even when running as a regular (elevated) administrator.
+        // wireguard-tools' wg.exe verifies the pipe owner is SYSTEM before connecting.
+        windows::enable_privilege("SeRestorePrivilege")?;
+
+        let sd = windows::SecurityDescriptor::for_wireguard_pipe()?;
+
+        tokio::spawn(async move {
+            // Windows named pipes require a new server instance per accepted client.
+            // The first instance must set first_pipe_instance(true) to ensure exclusive creation.
+            let mut first = true;
+            loop {
+                let server = windows::create_named_pipe(&pipe_path, &sd, first);
+                let server = match server {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("Failed to create named pipe: {e}");
+                        break;
+                    }
+                };
+                match server.connect().await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        log::error!("Failed to accept named pipe connection: {e}");
+                        break;
+                    }
+                }
+                first = false;
+
+                log::debug!("New UAPI connection on named pipe");
+
+                let client = tx.clone();
+                tokio::spawn(async move {
+                    let (r, w) = tokio::io::split(server);
+                    run_uapi_protocol(client, r, w).await;
+                });
+            }
+        });
+
+        Ok(rx)
     }
 
     /// Create an [`UapiServer`] from a reader+writer that speaks the official
@@ -258,6 +266,125 @@ impl UapiServer {
 
         Some((request, response_tx))
     }
+}
+
+/// Drives a single UAPI connection to completion.
+///
+/// Reads WireGuard text-protocol commands from `r`, dispatches them through `client`, and writes
+/// responses to `w`. Used by both the Unix (via [`UapiClient::wrap_read_write`]) and Windows (via
+/// [`UapiServer::default_named_pipe`]) code paths.
+async fn run_uapi_protocol(
+    client: UapiClient,
+    r: impl tokio::io::AsyncRead + Unpin,
+    mut w: impl tokio::io::AsyncWrite + Unpin,
+) {
+    use tokio::io::AsyncBufReadExt;
+
+    let mut reader = tokio::io::BufReader::new(r).lines();
+    let mut buf = String::new();
+
+    loop {
+        let line = match reader.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) | Err(_) => {
+                if !buf.is_empty() {
+                    if let Err(e) = dispatch_request(&client, &mut w, &buf).await {
+                        log::error!("Failed to handle UAPI request: {e:#}");
+                    }
+                }
+                return;
+            }
+        };
+
+        // Final line of a command is empty, so if this one is not, we add it to the
+        // `buf` buffer and wait for more.
+        if !line.is_empty() {
+            buf.push_str(&line);
+            buf.push('\n');
+            continue;
+        }
+
+        if buf.is_empty() {
+            continue;
+        }
+
+        if let Err(e) = dispatch_request(&client, &mut w, &buf).await {
+            log::error!("Failed to handle UAPI request: {e:#}");
+            return;
+        }
+
+        buf.clear();
+    }
+}
+
+async fn dispatch_request(
+    client: &UapiClient,
+    w: &mut (impl tokio::io::AsyncWrite + Unpin),
+    s: &str,
+) -> eyre::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let request = Request::from_str(s).wrap_err("Failed to parse command")?;
+
+    let Some(response) = client.send(request).await.ok() else {
+        bail!("Server hung up");
+    };
+
+    let response_str = format!("{response}\n");
+    if let Err(e) = w.write_all(response_str.as_bytes()).await {
+        log::error!("Failed to write API response: {e}");
+    }
+
+    Ok(())
+}
+
+/// Synchronous counterpart of [`run_uapi_protocol`] for use with blocking [`Read`]+[`Write`]
+/// streams (see [`UapiClient::wrap_read_write`]).
+fn run_uapi_protocol_sync(client: UapiClient, r: impl Read, mut w: impl Write) {
+    let r = BufReader::new(r);
+    let mut buf = String::new();
+
+    for line in r.lines() {
+        let Ok(line) = line else {
+            if !buf.is_empty() {
+                if let Err(e) = dispatch_request_sync(&client, &mut w, &buf) {
+                    log::error!("Failed to handle UAPI request: {e:#}");
+                }
+            }
+            return;
+        };
+
+        if !line.is_empty() {
+            buf.push_str(&line);
+            buf.push('\n');
+            continue;
+        }
+
+        if buf.is_empty() {
+            continue;
+        }
+
+        if let Err(e) = dispatch_request_sync(&client, &mut w, &buf) {
+            log::error!("Failed to handle UAPI request: {e:#}");
+            return;
+        }
+
+        buf.clear();
+    }
+}
+
+fn dispatch_request_sync(client: &UapiClient, w: &mut impl Write, s: &str) -> eyre::Result<()> {
+    let request = Request::from_str(s).wrap_err("Failed to parse command")?;
+
+    let Some(response) = client.send_sync(request).ok() else {
+        bail!("Server hung up");
+    };
+
+    if let Err(e) = writeln!(w, "{response}") {
+        log::error!("Failed to write API response: {e}");
+    }
+
+    Ok(())
 }
 
 impl Debug for UapiServer {
@@ -573,4 +700,162 @@ async fn on_api_set(
     }
 
     (SetResponse { errno: 0 }, reconfigure)
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use windows_sys::Win32::Foundation::{FALSE, LUID};
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+    };
+    use windows_sys::Win32::Security::{
+        AdjustTokenPrivileges, LookupPrivilegeValueW, SE_PRIVILEGE_ENABLED,
+        TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    use windows_sys::w;
+
+    /// RAII wrapper for a security descriptor allocated by Windows APIs.
+    /// Frees the memory via `LocalFree` on drop.
+    pub struct SecurityDescriptor(*mut core::ffi::c_void);
+
+    // SAFETY: `SecurityDescriptor` is thread safe.
+    unsafe impl Send for SecurityDescriptor {}
+    // SAFETY: `SecurityDescriptor` is thread safe.
+    unsafe impl Sync for SecurityDescriptor {}
+
+    impl Drop for SecurityDescriptor {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` was allocated by Windows in
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW`, which documents that
+            // the caller must release the buffer with `LocalFree`. `SecurityDescriptor` is
+            // the sole owner of the pointer, so this drop runs exactly once per allocation.
+            unsafe {
+                windows_sys::Win32::Foundation::LocalFree(self.0);
+            }
+        }
+    }
+
+    impl SecurityDescriptor {
+        /// Build the security descriptor used for the WireGuard UAPI named pipe:
+        /// owned by SYSTEM (`O:SY`) with a DACL granting full access to SYSTEM and
+        /// Administrators only.
+        pub fn for_wireguard_pipe() -> eyre::Result<Self> {
+            let mut sd = std::ptr::null_mut();
+            // SAFETY: `w!` yields a `'static` NUL-terminated UTF-16 pointer that outlives
+            // the call. `&mut sd` is a valid out-pointer; on success Windows writes a
+            // heap-allocated security descriptor into it which we immediately hand to
+            // `SecurityDescriptor` for RAII cleanup via `LocalFree`. The trailing size
+            // out-pointer is null because we don't need the length back.
+            let ret = unsafe {
+                ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    w!("O:SYD:(A;;GA;;;SY)(A;;GA;;;BA)"),
+                    SDDL_REVISION_1,
+                    &mut sd,
+                    std::ptr::null_mut(),
+                )
+            };
+            if ret == 0 {
+                eyre::bail!(
+                    "ConvertStringSecurityDescriptorToSecurityDescriptorW failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            Ok(SecurityDescriptor(sd))
+        }
+    }
+
+    /// Enable a Windows privilege (e.g. `SeRestorePrivilege`) on the current process token.
+    pub fn enable_privilege(name: &str) -> eyre::Result<()> {
+        let mut raw_token = std::ptr::null_mut();
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle that is always valid and
+        // does not need to be closed. `&mut raw_token` is a valid out-pointer; on success
+        // Windows writes a real process-token handle into it.
+        let ret = unsafe {
+            OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &mut raw_token)
+        };
+        if ret == 0 {
+            eyre::bail!(
+                "OpenProcessToken failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        // SAFETY: `raw_token` is an owned process-token handle that may be freed via [`CloseHandle`](https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle).
+        let token = unsafe { OwnedHandle::from_raw_handle(raw_token) };
+
+        let priv_name: Vec<u16> = name.encode_utf16().chain(Some(0)).collect();
+        let mut luid = LUID {
+            LowPart: 0,
+            HighPart: 0,
+        };
+        // SAFETY: A null `lpSystemName` means "the local system" per the Win32 docs.
+        // `priv_name` is a NUL-terminated UTF-16 string that outlives the call, and
+        // `&mut luid` is a valid out-pointer to a stack-allocated `LUID`.
+        let ret = unsafe { LookupPrivilegeValueW(std::ptr::null(), priv_name.as_ptr(), &mut luid) };
+        if ret == 0 {
+            eyre::bail!(
+                "LookupPrivilegeValueW failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+
+        let tp = TOKEN_PRIVILEGES {
+            PrivilegeCount: 1,
+            Privileges: [windows_sys::Win32::Security::LUID_AND_ATTRIBUTES {
+                Luid: luid,
+                Attributes: SE_PRIVILEGE_ENABLED,
+            }],
+        };
+        // SAFETY: `token` is a valid handle with `TOKEN_ADJUST_PRIVILEGES` access. `&tp`
+        // points to a fully-initialized `TOKEN_PRIVILEGES` whose `PrivilegeCount` matches its
+        // its array length (1). We don't request the previous state, so the `BufferLength`,
+        // `PreviousState`, and `ReturnLength` parameters are all zero/null.
+        let ret = unsafe {
+            AdjustTokenPrivileges(
+                token.as_raw_handle(),
+                FALSE,
+                &tp,
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ret == 0 {
+            eyre::bail!(
+                "AdjustTokenPrivileges failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Create a named pipe with the given security descriptor using tokio's `ServerOptions`.
+    pub fn create_named_pipe(
+        pipe_path: &str,
+        sd: &SecurityDescriptor,
+        first: bool,
+    ) -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+        use tokio::net::windows::named_pipe::ServerOptions;
+        use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
+        let mut sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: sd.0,
+            bInheritHandle: 0,
+        };
+
+        let mut builder = ServerOptions::new();
+        builder.first_pipe_instance(first);
+        // SAFETY: `create_with_security_attributes_raw` requires the pointer to outlive
+        // the call and to point at a valid `SECURITY_ATTRIBUTES`. `sa` lives on the stack
+        // for the entire duration of the call, its `nLength` is set correctly, and
+        // `lpSecurityDescriptor` borrows from `sd`, which the caller keeps alive (the
+        // `&SecurityDescriptor` borrow guarantees this for the lifetime of the function).
+        // The OS only reads the structure; it does not retain the pointer past return.
+        unsafe {
+            builder.create_with_security_attributes_raw(pipe_path, &mut sa as *mut _ as *mut _)
+        }
+    }
 }

--- a/gotatun/src/tun/tun_async_device.rs
+++ b/gotatun/src/tun/tun_async_device.rs
@@ -86,6 +86,23 @@ impl TunDevice {
         Ok(tun)
     }
 
+    /// Construct from a name with an explicit path to `wintun.dll`.
+    ///
+    /// Use this on Windows when `wintun.dll` is not on `PATH` or in the executable directory.
+    #[cfg(windows)]
+    pub fn from_name_with_wintun_path(
+        name: &str,
+        wintun_path: &std::path::Path,
+    ) -> Result<Self, Error> {
+        let mut tun_config = tun::Configuration::default();
+        tun_config.tun_name(name);
+        tun_config.platform_config(|p| {
+            p.wintun_file(wintun_path.as_os_str());
+        });
+        let tun = tun::create_as_async(&tun_config).map_err(Error::OpenTun)?;
+        TunDevice::from_tun_device(tun)
+    }
+
     /// Construct from a [`tun::AsyncDevice`].
     pub fn from_tun_device(tun: tun::AsyncDevice) -> Result<Self, Error> {
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
This also refactors the UAPI server to use tokio instead of blocking thread.

The CLI can be used to create a tunnel interface that supports UAPI. Use the standard `wg` tool to configure the interface, and use OS tools for routes and IP addresses.

# Usage

This is a bit cumbersome to use since you'd normally just use the Windows app, but here goes.

PowerShell:

```pwsh
# Create WireGuard tunnel device (needs to be its own window)
gotatun wg

# Set WG config
wg setconf wg wg.conf

# Add IP and routes
New-NetIPAddress -InterfaceAlias wg -IPAddress <tunnel IP> -PrefixLength 32
New-NetRoute -InterfaceAlias wg -DestinationPrefix <allowed IP>

# TODO: Also add a route for the endpoint via the default interface if allowed IPs includes the endpoint (e.g. 0.0.0.0/0).
```

# Todo

- [x] The named pipe location that's documented doesn't seem to work with `wg`. The actual location is `\\.\pipe\ProtectedPrefix\Administrators\WireGuard\` and seems to require setting a more restricted DACL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/118)
<!-- Reviewable:end -->
