### PR TITLE
Add `aws-lc-rs` as selectable AEAD crypto backend (and make it the default)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
       - name: Cache cargo directories
         id: cache-cargo-restore
         uses: actions/cache@v4
@@ -28,22 +31,10 @@ jobs:
             target
             target/doc
 
-      - name: Check all feature combinations
-        run: |
-          # Extract features from Cargo.toml
-          readarray -t features < <(cargo metadata --no-deps --format-version=1 | jq -r '.packages[].features | keys[]')
-          echo "Features: ${features[*]}"
-
-          echo "Checking docs with all features and all dependencies"
-          cargo doc --locked --release -p gotatun --all-features
-
-          echo "Checking docs with no features (no-deps)"
-          cargo doc --locked --release -p gotatun --no-default-features --no-deps
-
-          for feature in ${features[*]}; do
-            echo "Checking docs with --features=$feature (no-deps)"
-            cargo doc --locked --release -p gotatun --no-default-features --no-deps --features "$feature"
-          done
+      - name: Check documentation for each feature
+        # This includes running with --all-features, and then one time for each individual feature
+        # But always have aws-lc-rs enabled, since gotatun does not build without an AEAD backend.
+        run: cargo hack doc --locked -p gotatun --each-feature --features aws-lc-rs
 
       # Cache cargo directories, even if the job failed.
       - name: Always cache cargo dirs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "--deny warnings"
 
 jobs:
   check-linux:
@@ -173,7 +174,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
-        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets --all-features
 
   clippy-android:
     name: Clippy (Android)
@@ -215,7 +216,7 @@ jobs:
           key: ${{ runner.os }}-x86_64-linux-android-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
-        run: cargo clippy --locked --workspace --target x86_64-linux-android --all-features -- -D warnings
+        run: cargo clippy --locked --workspace --target x86_64-linux-android --all-features
 
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       matrix:
         features:
           - ""
-          - "--no-default-features"
+          - "--no-default-features --features ring"
           - "--all-features"
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
             target
           key: ${{ runner.os }}-x86_64-linux-android-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check with features ${{ matrix.features }}
+      - name: Check with features "${{ matrix.features }}"
         run: cargo check --locked --workspace --target x86_64-linux-android ${{ matrix.features }}
 
   check-other:
@@ -114,7 +114,7 @@ jobs:
         os: [windows-latest, macos-latest]
         features:
           - ""
-          - "--no-default-features"
+          - "--no-default-features --features ring"
           - "--all-features"
     runs-on: ${{ matrix.os }}
     steps:
@@ -132,7 +132,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check with features ${{ matrix.features }}
+      - name: Check with features "${{ matrix.features }}"
         run: cargo check --locked --workspace ${{ matrix.features }}
 
   fmt:
@@ -224,8 +224,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         features:
           - ""
+          - "--no-default-features --features ring"
           - "--all-features"
-          - "--no-default-features"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -242,5 +242,5 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run tests with features ${{ matrix.features }}
+      - name: Run tests with features "${{ matrix.features }}"
         run: cargo test --locked --workspace ${{ matrix.features }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -28,38 +31,11 @@ jobs:
 
       - name: Check all feature combinations
         run: |
-          # Extract features from Cargo.toml
-          readarray -t features < <(cargo metadata --no-deps --format-version=1 | jq -r '.packages[].features | keys[]')
-          echo "Features: ${features[*]}"
-
-          test_feature_combinations() {
-            local arr=("$@")
-            local n=${#arr[@]}
-
-            for ((i=0; i<$((1<<n)); i++)); do
-              combination=()
-              for ((j=0; j<n; j++)); do
-                if ((i & (1<<j))); then
-                  combination+=("${arr[j]}")
-                fi
-              done
-
-              if [ ${#combination[@]} -eq 0 ]; then
-                feature_str=""
-              else
-                feature_str=$(IFS=,; echo "${combination[*]}")
-              fi
-
-              echo "Testing with features: ${feature_str:-"none"}"
-              if [ -z "$feature_str" ]; then
-                cargo check --locked --workspace --no-default-features
-              else
-                cargo check --locked --workspace --no-default-features --features "$feature_str"
-              fi
-            done
-          }
-
-          test_feature_combinations "${features[@]}"
+          cargo hack check --locked --workspace \
+            --feature-powerset \
+            --at-least-one-of ring,aws-lc-rs \
+            --mutually-exclusive-features ring,aws-lc-rs \
+            --exclude-features default
 
   check-android:
     name: Check (Android)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ring` and `aws-lc-rs` Cargo features to both `gotatun` and
   `gotatun-cli`, selecting the AEAD backend at compile time. `aws-lc-rs`
   is the new default. `aws-lc-rs` wins if both features are enabled, and
-  a deprecation warning fires in that case to flag that `ring` is being
-  compiled and linked unnecessarily.
+  then `ring` is built and linked for nothing.
 
 ### Changed
 - The default AEAD backend is now `aws-lc-rs`. Consumers that still want

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `ring` and `aws-lc-rs` Cargo features to both `gotatun` and
+  `gotatun-cli`, selecting the AEAD backend at compile time. `aws-lc-rs`
+  is the new default. `aws-lc-rs` wins if both features are enabled, and
+  a deprecation warning fires in that case to flag that `ring` is being
+  compiled and linked unnecessarily.
+
+### Changed
+- The default AEAD backend is now `aws-lc-rs`. Consumers that still want
+  `ring` can opt in by building with `--no-default-features --features ring`.
+- Make the `ring` dependency optional, gated behind the new `ring` feature.
 
 
 ## [0.5.1] - 2026-04-02

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +293,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -410,6 +435,15 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -601,6 +635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "duplicate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +760,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -858,6 +904,7 @@ name = "gotatun"
 version = "0.5.1"
 dependencies = [
  "aead",
+ "aws-lc-rs",
  "base64",
  "bitfield-struct",
  "blake2",
@@ -893,7 +940,7 @@ dependencies = [
  "tokio-stream",
  "tun",
  "typed-builder",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "x25519-dalek",
  "zerocopy",
 ]
@@ -1040,6 +1087,16 @@ name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1511,7 +1568,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2024,6 +2081,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 aead = "0.5.2"
+aws-lc-rs = "1.16.2"
 base64 = "0.22.1"
 bitfield-struct = "0.12.1"
 blake2 = "0.10.6"
@@ -31,7 +32,7 @@ either = "1.15.0"
 etherparse = "0.13"
 eyre = "0.6.12"
 futures = "0.3.31"
-gotatun = { path = "./gotatun", version = "0.5.1" }
+gotatun = { path = "./gotatun", version = "0.5.1", default-features = false }
 hex = "0.4.3"
 hmac = "0.12.1"
 ip_network = "0.4.1"

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -33,3 +33,11 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[features]
+default = ["aws-lc-rs"]
+# Use the `ring` crate as the AEAD backend. Combine with
+# `--no-default-features` to avoid also pulling in `aws-lc-rs`.
+ring = ["gotatun/ring"]
+# Use the `aws-lc-rs` crate as the AEAD backend. Default.
+aws-lc-rs = ["gotatun/aws-lc-rs"]

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -33,6 +33,7 @@ harness = false
 
 [dependencies]
 aead = { workspace = true }
+aws-lc-rs = { workspace = true, optional = true }
 base64 = { workspace = true }
 bitfield-struct = { workspace = true }
 blake2 = { workspace = true }
@@ -57,7 +58,7 @@ pcap-file = { workspace = true, optional = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rand_core = { workspace = true, features = ["getrandom"] }
-ring = { workspace = true }
+ring = { workspace = true, optional = true }
 socket2 = { workspace = true, features = ["all"] }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net"] }
@@ -96,8 +97,16 @@ nix = { workspace = true, default-features = false, features = [
 ] }
 
 [features]
-default = []
+default = ["aws-lc-rs"]
 daita = ["device", "dep:maybenot"]
+# Use the `ring` crate as the AEAD backend. Combine with
+# `default-features = false` to avoid also pulling in `aws-lc-rs`,
+# which would otherwise be compiled and linked unused.
+ring = ["dep:ring"]
+# Use the `aws-lc-rs` crate as the AEAD backend. Default. At least
+# one of `ring` and `aws-lc-rs` must be enabled; `aws-lc-rs` wins
+# if both are.
+aws-lc-rs = ["dep:aws-lc-rs"]
 # Add non-compliant UAPI support for DAITA.
 # See `UAPI.md` for details.
 daita-uapi = ["daita"]

--- a/gotatun/benches/crypto_benches/chacha20poly1305_benching.rs
+++ b/gotatun/benches/crypto_benches/chacha20poly1305_benching.rs
@@ -9,12 +9,32 @@
 //   Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 //
 // SPDX-License-Identifier: MPL-2.0
+//! Benchmarks the configured GotaTun AEAD backend (`ring` or `aws-lc-rs`,
+//! both wrapping a hardware-accelerated C implementation) against the
+//! pure-Rust [`chacha20poly1305`] crate on the same workload, to track the
+//! gap between our production backend and a portable software fallback.
+
 use aead::{AeadInPlace, KeyInit};
+#[cfg(feature = "aws-lc-rs")]
+use aws_lc_rs::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use criterion::{BenchmarkId, Criterion, Throughput};
 use rand::{TryRngCore, rngs::OsRng};
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
 use ring::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 
-fn chacha20poly1305_ring(key_bytes: &[u8], buf: &mut [u8]) {
+/// Name of the configured GotaTun AEAD backend, used as the benchmark id.
+/// Mirrors the precedence used by the `gotatun::crypto` module.
+#[cfg(feature = "aws-lc-rs")]
+const BACKEND_NAME: &str = "aws_lc_rs";
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+const BACKEND_NAME: &str = "ring";
+
+/// Name of the pure-Rust comparison AEAD implementation.
+const PURE_RUST_NAME: &str = "chacha20poly1305_crate";
+
+/// Encrypt `buf` in place using the GotaTun-configured AEAD backend
+/// (`ring` or `aws-lc-rs`).
+fn chacha20poly1305_backend(key_bytes: &[u8], buf: &mut [u8]) {
     let len = buf.len();
     let n = len - 16;
 
@@ -31,7 +51,9 @@ fn chacha20poly1305_ring(key_bytes: &[u8], buf: &mut [u8]) {
     buf[n..].copy_from_slice(tag.as_ref())
 }
 
-fn chacha20poly1305_non_ring(key_bytes: &[u8], buf: &mut [u8]) {
+/// Encrypt `buf` in place using the pure-Rust [`chacha20poly1305`] crate,
+/// for side-by-side comparison with the configured backend above.
+fn chacha20poly1305_pure_rust(key_bytes: &[u8], buf: &mut [u8]) {
     let len = buf.len();
     let n = len - 16;
 
@@ -53,37 +75,29 @@ pub fn bench_chacha20poly1305(c: &mut Criterion) {
     for size in [128, 192, 1400, 8192] {
         group.throughput(Throughput::Bytes(size as u64));
 
-        group.bench_with_input(
-            BenchmarkId::new("chacha20poly1305_ring", size),
-            &size,
-            |b, i| {
-                let mut key = [0; 32];
-                let mut buf = vec![0; i + 16];
+        group.bench_with_input(BenchmarkId::new(BACKEND_NAME, size), &size, |b, i| {
+            let mut key = [0; 32];
+            let mut buf = vec![0; i + 16];
 
-                let mut rng = OsRng;
+            let mut rng = OsRng;
 
-                rng.try_fill_bytes(&mut key).unwrap();
-                rng.try_fill_bytes(&mut buf).unwrap();
+            rng.try_fill_bytes(&mut key).unwrap();
+            rng.try_fill_bytes(&mut buf).unwrap();
 
-                b.iter(|| chacha20poly1305_ring(&key, &mut buf));
-            },
-        );
+            b.iter(|| chacha20poly1305_backend(&key, &mut buf));
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("chacha20poly1305_non_ring", size),
-            &size,
-            |b, i| {
-                let mut key = [0; 32];
-                let mut buf = vec![0; i + 16];
+        group.bench_with_input(BenchmarkId::new(PURE_RUST_NAME, size), &size, |b, i| {
+            let mut key = [0; 32];
+            let mut buf = vec![0; i + 16];
 
-                let mut rng = OsRng;
+            let mut rng = OsRng;
 
-                rng.try_fill_bytes(&mut key).unwrap();
-                rng.try_fill_bytes(&mut buf).unwrap();
+            rng.try_fill_bytes(&mut key).unwrap();
+            rng.try_fill_bytes(&mut buf).unwrap();
 
-                b.iter(|| chacha20poly1305_non_ring(&key, &mut buf));
-            },
-        );
+            b.iter(|| chacha20poly1305_pure_rust(&key, &mut buf));
+        });
     }
 
     group.finish();

--- a/gotatun/src/crypto.rs
+++ b/gotatun/src/crypto.rs
@@ -14,9 +14,8 @@
 //! and takes precedence when both are enabled. At least one feature
 //! must be enabled.
 //!
-//! Enabling both backends compiles and links `ring` for nothing, so a
-//! `deprecated` warning fires to nudge consumers toward disabling
-//! default features and selecting a single backend.
+//! Enabling both backends compiles and links `ring` for nothing.
+//! Disable default features if you plan on using ring.
 
 #[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
 compile_error!(
@@ -28,15 +27,3 @@ pub use aws_lc_rs::{aead, error};
 
 #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
 pub use ring::{aead, error};
-
-// Warn when both backends are enabled: `aws-lc-rs` wins, so `ring` is
-// compiled and linked but unused. Use a `#[deprecated]` const and
-// reference it to make rustc emit a warning.
-#[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
-const _: () = {
-    #[deprecated(note = "both `ring` and `aws-lc-rs` gotatun features are enabled; \
-                `ring` is compiled and linked but unused. Disable default \
-                features and pick a single backend.")]
-    const BOTH_AEAD_BACKENDS_ENABLED: () = ();
-    BOTH_AEAD_BACKENDS_ENABLED
-};

--- a/gotatun/src/crypto.rs
+++ b/gotatun/src/crypto.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! ChaCha20-Poly1305 AEAD backend, selected at compile time by the
+//! `aws-lc-rs` and `ring` Cargo features. `aws-lc-rs` is the default
+//! and takes precedence when both are enabled. At least one feature
+//! must be enabled.
+//!
+//! Enabling both backends compiles and links `ring` for nothing, so a
+//! `deprecated` warning fires to nudge consumers toward disabling
+//! default features and selecting a single backend.
+
+#[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+compile_error!(
+    "gotatun requires at least one of the `ring` or `aws-lc-rs` Cargo features to be enabled"
+);
+
+#[cfg(feature = "aws-lc-rs")]
+pub use aws_lc_rs::{aead, error};
+
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+pub use ring::{aead, error};
+
+// Warn when both backends are enabled: `aws-lc-rs` wins, so `ring` is
+// compiled and linked but unused. Use a `#[deprecated]` const and
+// reference it to make rustc emit a warning.
+#[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
+const _: () = {
+    #[deprecated(note = "both `ring` and `aws-lc-rs` gotatun features are enabled; \
+                `ring` is compiled and linked but unused. Disable default \
+                features and pick a single backend.")]
+    const BOTH_AEAD_BACKENDS_ENABLED: () = ();
+    BOTH_AEAD_BACKENDS_ENABLED
+};

--- a/gotatun/src/lib.rs
+++ b/gotatun/src/lib.rs
@@ -15,6 +15,7 @@
 // Warn on missing docs when running `cargo doc`
 #![cfg_attr(doc, warn(missing_docs))]
 
+mod crypto;
 #[cfg(feature = "device")]
 pub mod device;
 pub mod noise;

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::crypto::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use crate::noise::errors::WireGuardError;
 use crate::noise::index_table::{Index, IndexTable};
 use crate::noise::session::Session;
@@ -22,7 +23,6 @@ use blake2::digest::{FixedOutput, KeyInit};
 use blake2::{Blake2s256, Blake2sMac, Digest};
 use chacha20poly1305::XChaCha20Poly1305;
 use constant_time_eq::constant_time_eq_n;
-use ring::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 use zerocopy::IntoBytes;
@@ -153,7 +153,7 @@ fn aead_chacha20_open_inner(
     nonce: [u8; 12],
     data: &[u8],
     aad: &[u8],
-) -> Result<(), ring::error::Unspecified> {
+) -> Result<(), crate::crypto::error::Unspecified> {
     let key = LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, key).unwrap());
 
     let mut inner_buffer = data.to_owned();

--- a/gotatun/src/noise/session.rs
+++ b/gotatun/src/noise/session.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::crypto::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use crate::{
     noise::errors::WireGuardError,
     noise::index_table::Index,
@@ -17,7 +18,6 @@ use crate::{
 };
 use bytes::{Buf, BytesMut};
 use parking_lot::Mutex;
-use ring::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use std::sync::atomic::{AtomicU64, Ordering};
 use zerocopy::FromBytes;
 


### PR DESCRIPTION
Introduce `ring` and `aws-lc-rs` Cargo features on both `gotatun` and `gotatun-cli` that pick the ChaCha20-Poly1305 AEAD backend used by the WireGuard handshake and data encryption. `aws-lc-rs` is the new default; consumers that want `ring` can opt in by building with `--no-default-features --features ring`.

Selection is done at compile time by a private `crypto` module that re-exports the configured backend's `aead` and `error` modules. Both crates expose an API-compatible `aead` interface, so the rest of the codebase only needs to switch its imports from `ring::*` to `crate::crypto::*`.

If both features are enabled, `aws-lc-rs` wins and `ring` is compiled and linked unused. A `#[deprecated]` shim fires a compile warning in that case so the unnecessary dependency is easy to spot and drop. Building with neither feature enabled produces a clear `compile_error!`.

The ChaCha20-Poly1305 crypto benchmark now runs against the configured backend and is renamed to reflect what it actually measures, alongside the existing pure-Rust `chacha20poly1305` crate comparison.

Do we consider this a breaking change? Adding features is not breaking. And technically the API does not change. But we could decide that changing the crypto implementation is a large enough change to warrant a breaking bump. If we want to be more conservative we can also keep `ring` as the default backend. But I think `aws-lc-rs` is the desired backend going forward so I figured we could go there directly.

This address finding [3.9 Usage of the crate ring (NOTE)](https://github.com/mullvad/gotatun/blob/main/audits/2026-02-17-Assured.md#39-usage-of-the-crate-ring-note) from the latest GotaTun audit by not using `ring` by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/122)
<!-- Reviewable:end -->
