### PR TITLE
Keep the live tunnel PSK in sync in modify_peer() / update_peer()

### DIFF
--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -320,7 +320,13 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
         } = peer_mut;
 
         if let Update::Set(preshared_key) = preshared_key {
-            existing_peer.preshared_key = preshared_key;
+            if existing_peer.preshared_key != preshared_key {
+                // Keep the stored config and live tunnel in sync. `modify_peer` / `update_peer`
+                // are expected to affect subsequent handshakes, not only the value returned by
+                // inspection APIs.
+                existing_peer.preshared_key = preshared_key;
+                existing_peer.tunnel.set_preshared_key(preshared_key);
+            }
         }
 
         if let Update::Set(keepalive) = keepalive {

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -321,7 +321,13 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
         } = peer_mut;
 
         if let Update::Set(preshared_key) = preshared_key {
-            existing_peer.preshared_key = preshared_key;
+            if existing_peer.preshared_key != preshared_key {
+                // Keep the stored config and live tunnel in sync. `modify_peer` / `update_peer`
+                // are expected to affect subsequent handshakes, not only the value returned by
+                // inspection APIs.
+                existing_peer.preshared_key = preshared_key;
+                existing_peer.tunnel.set_preshared_key(preshared_key);
+            }
         }
 
         if let Update::Set(keepalive) = keepalive {

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -185,7 +185,7 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
             peers.push(PeerStats {
                 peer: Peer {
                     public_key: *pubkey,
-                    preshared_key: p.preshared_key,
+                    preshared_key: p.tunnel.preshared_key(),
                     allowed_ips: p.allowed_ips.iter().map(|(_, net)| net).collect(),
                     endpoint: p.endpoint.addr,
                     keepalive: p.tunnel.persistent_keepalive(),
@@ -321,13 +321,7 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
         } = peer_mut;
 
         if let Update::Set(preshared_key) = preshared_key {
-            if existing_peer.preshared_key != preshared_key {
-                // Keep the stored config and live tunnel in sync. `modify_peer` / `update_peer`
-                // are expected to affect subsequent handshakes, not only the value returned by
-                // inspection APIs.
-                existing_peer.preshared_key = preshared_key;
-                existing_peer.tunnel.set_preshared_key(preshared_key);
-            }
+            existing_peer.tunnel.set_preshared_key(preshared_key);
         }
 
         if let Update::Set(keepalive) = keepalive {

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -380,7 +380,6 @@ impl<T: DeviceTransports> DeviceState<T> {
             tunn,
             peer_builder.endpoint,
             peer_builder.allowed_ips.as_slice(),
-            peer_builder.preshared_key,
             #[cfg(feature = "daita")]
             peer_builder.daita_settings,
         )

--- a/gotatun/src/device/peer_state.rs
+++ b/gotatun/src/device/peer_state.rs
@@ -37,7 +37,6 @@ pub struct PeerState {
     pub(crate) tunnel: Tunn,
     pub(crate) endpoint: Endpoint,
     pub(crate) allowed_ips: AllowedIps<()>,
-    pub(crate) preshared_key: Option<[u8; 32]>,
 
     #[cfg(feature = "daita")]
     daita_settings: Option<DaitaSettings>,
@@ -50,14 +49,12 @@ impl PeerState {
         tunnel: Tunn,
         endpoint: Option<SocketAddr>,
         allowed_ips: &[IpNetwork],
-        preshared_key: Option<[u8; 32]>,
         #[cfg(feature = "daita")] daita_settings: Option<DaitaSettings>,
     ) -> PeerState {
         Self {
             tunnel,
             endpoint: Endpoint { addr: endpoint },
             allowed_ips: allowed_ips.iter().map(|ip| (ip, ())).collect(),
-            preshared_key,
             #[cfg(feature = "daita")]
             daita_settings,
             #[cfg(feature = "daita")]
@@ -123,5 +120,9 @@ impl PeerState {
 
     pub fn persistent_keepalive(&self) -> Option<u16> {
         self.tunnel.persistent_keepalive()
+    }
+
+    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+        self.tunnel.preshared_key()
     }
 }

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -14,10 +14,14 @@ use std::{future::ready, time::Duration};
 use futures::{StreamExt, future::pending};
 use mock::MockEavesdropper;
 use rand::{SeedableRng, rngs::StdRng};
-use tokio::{join, select, time::sleep};
+use tokio::{
+    join, select,
+    time::{sleep, timeout},
+};
 use zerocopy::IntoBytes;
 
 use crate::noise::index_table::IndexTable;
+use crate::packet::{Ip, Packet};
 
 pub mod mock;
 
@@ -179,9 +183,99 @@ async fn test_endpoint_roaming() {
     ping_pong("1.2.3.4".parse().unwrap()).await;
 }
 
+#[derive(Clone, Copy)]
+enum PeerUpdateApi {
+    Modify,
+    Update,
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn modify_peer_updates_live_preshared_key() {
+    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Modify).await;
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn update_peer_updates_live_preshared_key() {
+    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Update).await;
+}
+
 /// The number of packets we send through the tunnel
 fn packet_count() -> usize {
     mock::packets_of_every_size().len()
+}
+
+async fn assert_peer_psk_update_changes_live_handshake(api: PeerUpdateApi) {
+    let (mut alice, mut bob, _eve) = mock::device_pair().await;
+    let packet = mock::packet(b"Hello!");
+    let preshared_key = [0xA5; 32];
+
+    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
+    send_and_expect_blocked(&alice, &mut bob, &packet).await;
+
+    apply_peer_psk_update(&mut bob, api, Some(preshared_key)).await;
+    // Reset Alice's failed in-flight handshake so the next packet starts a fresh exchange.
+    apply_peer_psk_update(&mut alice, api, Some([0x5A; 32])).await;
+    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
+
+    send_and_expect_delivery(&alice, &mut bob, &packet).await;
+}
+
+async fn apply_peer_psk_update(
+    device: &mut mock::MockDevice,
+    api: PeerUpdateApi,
+    preshared_key: Option<[u8; 32]>,
+) {
+    let mut peers = device.device.peers().await;
+    assert_eq!(peers.len(), 1, "expected exactly one peer");
+
+    let mut peer = peers.pop().expect("missing peer").peer;
+    let updated = match api {
+        PeerUpdateApi::Modify => device
+            .device
+            .modify_peer(&peer.public_key, |peer_mut| {
+                peer_mut.set_preshared_key(preshared_key);
+            })
+            .await
+            .expect("modify_peer should succeed"),
+        PeerUpdateApi::Update => {
+            peer.preshared_key = preshared_key;
+            device
+                .device
+                .update_peer(peer)
+                .await
+                .expect("update_peer should succeed")
+        }
+    };
+
+    assert!(updated, "peer update should affect an existing peer");
+}
+
+async fn send_and_expect_blocked(
+    sender: &mock::MockDevice,
+    receiver: &mut mock::MockDevice,
+    packet: &Packet<Ip>,
+) {
+    sender.app_tx.send(packet.clone()).await;
+    assert!(
+        timeout(Duration::from_millis(500), receiver.app_rx.recv())
+            .await
+            .is_err(),
+        "packet should not be delivered while peers disagree on the live PSK"
+    );
+}
+
+async fn send_and_expect_delivery(
+    sender: &mock::MockDevice,
+    receiver: &mut mock::MockDevice,
+    packet: &Packet<Ip>,
+) {
+    sender.app_tx.send(packet.clone()).await;
+    let received = timeout(Duration::from_secs(1), receiver.app_rx.recv())
+        .await
+        .expect("expected packet delivery once both live PSKs match");
+    assert_eq!(received.as_bytes(), packet.as_bytes());
 }
 
 /// Helper method to test that packets can be sent from one [`Device`] to another.

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -298,6 +298,9 @@ async fn apply_peer_psk_update(
         }
     };
 
+    #[cfg(feature = "mock_instant")]
+    mock_instant::thread_local::MockClock::advance(Duration::from_micros(1));
+
     assert!(updated, "peer update should affect an existing peer");
 }
 

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -14,10 +14,14 @@ use std::{future::ready, time::Duration};
 use futures::{StreamExt, future::pending};
 use mock::MockEavesdropper;
 use rand::{SeedableRng, rngs::StdRng};
-use tokio::{join, select, time::sleep};
+use tokio::{
+    join, select,
+    time::{sleep, timeout},
+};
 use zerocopy::IntoBytes;
 
 use crate::noise::index_table::IndexTable;
+use crate::packet::{Ip, Packet};
 
 pub mod mock;
 
@@ -228,9 +232,99 @@ async fn reverse_path_rejects_source_owned_by_another_peer() {
     );
 }
 
+#[derive(Clone, Copy)]
+enum PeerUpdateApi {
+    Modify,
+    Update,
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn modify_peer_updates_live_preshared_key() {
+    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Modify).await;
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn update_peer_updates_live_preshared_key() {
+    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Update).await;
+}
+
 /// The number of packets we send through the tunnel
 fn packet_count() -> usize {
     mock::packets_of_every_size().len()
+}
+
+async fn assert_peer_psk_update_changes_live_handshake(api: PeerUpdateApi) {
+    let (mut alice, mut bob, _eve) = mock::device_pair().await;
+    let packet = mock::packet(b"Hello!");
+    let preshared_key = [0xA5; 32];
+
+    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
+    send_and_expect_blocked(&alice, &mut bob, &packet).await;
+
+    apply_peer_psk_update(&mut bob, api, Some(preshared_key)).await;
+    // Reset Alice's failed in-flight handshake so the next packet starts a fresh exchange.
+    apply_peer_psk_update(&mut alice, api, Some([0x5A; 32])).await;
+    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
+
+    send_and_expect_delivery(&alice, &mut bob, &packet).await;
+}
+
+async fn apply_peer_psk_update(
+    device: &mut mock::MockDevice,
+    api: PeerUpdateApi,
+    preshared_key: Option<[u8; 32]>,
+) {
+    let mut peers = device.device.peers().await;
+    assert_eq!(peers.len(), 1, "expected exactly one peer");
+
+    let mut peer = peers.pop().expect("missing peer").peer;
+    let updated = match api {
+        PeerUpdateApi::Modify => device
+            .device
+            .modify_peer(&peer.public_key, |peer_mut| {
+                peer_mut.set_preshared_key(preshared_key);
+            })
+            .await
+            .expect("modify_peer should succeed"),
+        PeerUpdateApi::Update => {
+            peer.preshared_key = preshared_key;
+            device
+                .device
+                .update_peer(peer)
+                .await
+                .expect("update_peer should succeed")
+        }
+    };
+
+    assert!(updated, "peer update should affect an existing peer");
+}
+
+async fn send_and_expect_blocked(
+    sender: &mock::MockDevice,
+    receiver: &mut mock::MockDevice,
+    packet: &Packet<Ip>,
+) {
+    sender.app_tx.send(packet.clone()).await;
+    assert!(
+        timeout(Duration::from_millis(500), receiver.app_rx.recv())
+            .await
+            .is_err(),
+        "packet should not be delivered while peers disagree on the live PSK"
+    );
+}
+
+async fn send_and_expect_delivery(
+    sender: &mock::MockDevice,
+    receiver: &mut mock::MockDevice,
+    packet: &Packet<Ip>,
+) {
+    sender.app_tx.send(packet.clone()).await;
+    let received = timeout(Duration::from_secs(1), receiver.app_rx.recv())
+        .await
+        .expect("expected packet delivery once both live PSKs match");
+    assert_eq!(received.as_bytes(), packet.as_bytes());
 }
 
 /// Helper method to test that packets can be sent from one [`Device`] to another.

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -501,7 +501,7 @@ async fn on_api_get(_: Get, d: &DeviceState<impl DeviceTransports>) -> GetRespon
             peer: Peer {
                 public_key: KeyBytes(*public_key.as_bytes()),
                 preshared_key: peer
-                    .preshared_key
+                    .preshared_key()
                     .map(|key| command::SetUnset::Set(KeyBytes(key))),
                 endpoint,
                 persistent_keepalive_interval: peer.persistent_keepalive(),
@@ -643,7 +643,7 @@ async fn on_api_set(
 
                 crate::device::Peer {
                     public_key,
-                    preshared_key: peer.preshared_key,
+                    preshared_key: peer.preshared_key(),
                     endpoint: peer.endpoint().addr,
                     keepalive: peer.persistent_keepalive(),
                     allowed_ips: if replace_allowed_ips {

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -434,6 +434,10 @@ impl NoiseParams {
 
         self.static_shared = self.static_private.diffie_hellman(&self.peer_static_public);
     }
+
+    fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.preshared_key = preshared_key;
+    }
 }
 
 impl Handshake {
@@ -497,6 +501,15 @@ impl Handshake {
         public_key: x25519::PublicKey,
     ) {
         self.params.set_static_private(private_key, public_key)
+    }
+
+    /// Update the preshared key and invalidate handshake state derived from the previous value.
+    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.params.set_preshared_key(preshared_key);
+        // Any in-flight handshake transcript was mixed with the previous PSK and cannot continue.
+        self.previous = HandshakeState::None;
+        self.state = HandshakeState::None;
+        self.last_rtt = None;
     }
 
     pub(super) fn receive_handshake_initialization(

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -435,6 +435,7 @@ impl NoiseParams {
         self.static_shared = self.static_private.diffie_hellman(&self.peer_static_public);
     }
 
+    #[cfg(any(feature = "device", test))]
     fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.preshared_key = preshared_key;
     }
@@ -504,11 +505,15 @@ impl Handshake {
     }
 
     /// Update the preshared key and invalidate handshake state derived from the previous value.
+    #[cfg(any(feature = "device", test))]
     pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.params.set_preshared_key(preshared_key);
         // Any in-flight handshake transcript was mixed with the previous PSK and cannot continue.
         self.previous = HandshakeState::None;
         self.state = HandshakeState::None;
+        // Replay protection for handshake initiations is tied to the previous crypto context.
+        // Reset it so an immediate retry after a PSK change is not rejected as stale.
+        self.last_handshake_timestamp = Tai64N::zero();
         self.last_rtt = None;
     }
 

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -435,7 +435,6 @@ impl NoiseParams {
         self.static_shared = self.static_private.diffie_hellman(&self.peer_static_public);
     }
 
-    #[cfg(any(feature = "device", test))]
     fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.preshared_key = preshared_key;
     }
@@ -501,20 +500,23 @@ impl Handshake {
         private_key: x25519::StaticSecret,
         public_key: x25519::PublicKey,
     ) {
-        self.params.set_static_private(private_key, public_key)
+        self.params.set_static_private(private_key, public_key);
+        // Invalidate in-flight handshakes
+        self.state = HandshakeState::None;
+        self.previous = HandshakeState::None;
     }
 
     /// Update the preshared key and invalidate handshake state derived from the previous value.
-    #[cfg(any(feature = "device", test))]
     pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.params.set_preshared_key(preshared_key);
-        // Any in-flight handshake transcript was mixed with the previous PSK and cannot continue.
-        self.previous = HandshakeState::None;
+        // Invalidate in-flight handshakes
         self.state = HandshakeState::None;
-        // Replay protection for handshake initiations is tied to the previous crypto context.
-        // Reset it so an immediate retry after a PSK change is not rejected as stale.
-        self.last_handshake_timestamp = Tai64N::zero();
-        self.last_rtt = None;
+        self.previous = HandshakeState::None;
+    }
+
+    /// Get the preshared key
+    pub(crate) fn preshared_key(&self) -> Option<[u8; 32]> {
+        self.params.preshared_key
     }
 
     pub(super) fn receive_handshake_initialization(

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -164,6 +164,7 @@ impl<R: RngCore + Send> Tunn<R> {
     }
 
     /// Update the preshared key and discard crypto state derived from the previous one.
+    #[cfg(any(feature = "device", test))]
     pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.handshake.set_preshared_key(preshared_key);
         // Established sessions are keyed from the previous PSK and must not remain usable.
@@ -819,6 +820,30 @@ mod tests {
             my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None),
             Some(WgKind::HandshakeInit(..))
         ));
+    }
+
+    #[test]
+    fn set_preshared_key_resets_handshake_replay_state() {
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        let preshared_key = [7; 32];
+
+        my_tun.set_preshared_key(Some(preshared_key));
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, init);
+        assert!(matches!(
+            my_tun.handle_incoming_packet(WgKind::HandshakeResp(resp)),
+            TunnResult::Err(WireGuardError::InvalidAeadTag)
+        ));
+
+        their_tun.set_preshared_key(Some(preshared_key));
+        my_tun.set_preshared_key(Some([8; 32]));
+        my_tun.set_preshared_key(Some(preshared_key));
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, init);
+        let keepalive = parse_handshake_resp(&mut my_tun, resp);
+        parse_keepalive(&mut their_tun, keepalive);
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -163,6 +163,17 @@ impl<R: RngCore + Send> Tunn<R> {
         }
     }
 
+    /// Update the preshared key and discard crypto state derived from the previous one.
+    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.handshake.set_preshared_key(preshared_key);
+        // Established sessions are keyed from the previous PSK and must not remain usable.
+        for s in &mut self.sessions {
+            *s = None;
+        }
+        // Reset timer-driven handshake/keepalive state so the next packet starts a fresh exchange.
+        self.timers.clear();
+    }
+
     /// Encapsulate a single packet.
     ///
     /// If there's an active session, return the encapsulated packet. Otherwise, if needed, return
@@ -793,6 +804,21 @@ mod tests {
             unreachable!("expected WritetoTunnelV4");
         };
         assert_eq!(sent_packet_buf.as_bytes(), recv_packet_buf.as_bytes());
+    }
+
+    #[test]
+    fn set_preshared_key_invalidates_existing_sessions() {
+        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake();
+
+        assert!(my_tun.time_since_last_handshake().is_some());
+
+        my_tun.set_preshared_key(Some([7; 32]));
+
+        assert!(my_tun.time_since_last_handshake().is_none());
+        assert!(matches!(
+            my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None),
+            Some(WgKind::HandshakeInit(..))
+        ));
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -163,6 +163,17 @@ impl<R: RngCore + Send> Tunn<R> {
         }
     }
 
+    /// Update the preshared key and discard crypto state derived from the previous one.
+    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.handshake.set_preshared_key(preshared_key);
+        // Established sessions are keyed from the previous PSK and must not remain usable.
+        for s in &mut self.sessions {
+            *s = None;
+        }
+        // Reset timer-driven handshake/keepalive state so the next packet starts a fresh exchange.
+        self.timers.clear();
+    }
+
     /// Encapsulate a single packet.
     ///
     /// If there's an active session, return the encapsulated packet. Otherwise, if needed, return
@@ -804,6 +815,21 @@ mod tests {
             unreachable!("expected WritetoTunnelV4");
         };
         assert_eq!(sent_packet_buf.as_bytes(), recv_packet_buf.as_bytes());
+    }
+
+    #[test]
+    fn set_preshared_key_invalidates_existing_sessions() {
+        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake();
+
+        assert!(my_tun.time_since_last_handshake().is_some());
+
+        my_tun.set_preshared_key(Some([7; 32]));
+
+        assert!(my_tun.time_since_last_handshake().is_none());
+        assert!(matches!(
+            my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None),
+            Some(WgKind::HandshakeInit(..))
+        ));
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -163,16 +163,18 @@ impl<R: RngCore + Send> Tunn<R> {
         }
     }
 
-    /// Update the preshared key and discard crypto state derived from the previous one.
-    #[cfg(any(feature = "device", test))]
-    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+    /// Update the preshared key and clear existing sessions.
+    pub fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.handshake.set_preshared_key(preshared_key);
         // Established sessions are keyed from the previous PSK and must not remain usable.
         for s in &mut self.sessions {
             *s = None;
         }
-        // Reset timer-driven handshake/keepalive state so the next packet starts a fresh exchange.
-        self.timers.clear();
+    }
+
+    /// Get the current preshared key.
+    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+        self.handshake.preshared_key()
     }
 
     /// Encapsulate a single packet.
@@ -850,6 +852,9 @@ mod tests {
         their_tun.set_preshared_key(Some(preshared_key));
         my_tun.set_preshared_key(Some([8; 32]));
         my_tun.set_preshared_key(Some(preshared_key));
+
+        #[cfg(feature = "mock_instant")]
+        mock_instant::thread_local::MockClock::advance(Duration::from_micros(1));
 
         let init = create_handshake_init(&mut my_tun);
         let resp = create_handshake_response(&mut their_tun, init);

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -164,6 +164,7 @@ impl<R: RngCore + Send> Tunn<R> {
     }
 
     /// Update the preshared key and discard crypto state derived from the previous one.
+    #[cfg(any(feature = "device", test))]
     pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.handshake.set_preshared_key(preshared_key);
         // Established sessions are keyed from the previous PSK and must not remain usable.
@@ -830,6 +831,30 @@ mod tests {
             my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None),
             Some(WgKind::HandshakeInit(..))
         ));
+    }
+
+    #[test]
+    fn set_preshared_key_resets_handshake_replay_state() {
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        let preshared_key = [7; 32];
+
+        my_tun.set_preshared_key(Some(preshared_key));
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, init);
+        assert!(matches!(
+            my_tun.handle_incoming_packet(WgKind::HandshakeResp(resp)),
+            TunnResult::Err(WireGuardError::InvalidAeadTag)
+        ));
+
+        their_tun.set_preshared_key(Some(preshared_key));
+        my_tun.set_preshared_key(Some([8; 32]));
+        my_tun.set_preshared_key(Some(preshared_key));
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, init);
+        let keepalive = parse_handshake_resp(&mut my_tun, resp);
+        parse_keepalive(&mut their_tun, keepalive);
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.


### PR DESCRIPTION
## Summary

`Device::modify_peer()` and `Device::update_peer()` updated the stored peer PSK, but left the live tunnel / handshake state unchanged.

That allowed the configured PSK and the runtime PSK to diverge, and could leave sessions / in-flight handshake state derived from the previous PSK usable after a PSK change.

## Fix

This patch makes PSK updates affect the live tunnel immediately:

- call `set_preshared_key()` on the live tunnel when a peer's configured PSK changes
- add `Tunn::set_preshared_key()` to:
  - update the handshake PSK
  - drop existing sessions
  - clear timer-driven state so the next packet starts a fresh exchange
- add `Handshake::set_preshared_key()` to:
  - update the stored handshake PSK
  - discard in-flight handshake state (`state`, `previous`, `last_rtt`)

## Why this approach

Changing the PSK is not just a config update; it invalidates crypto state derived from the previous PSK.

The library peer-update APIs are expected to affect subsequent handshakes, not only the values returned by configuration / inspection APIs. Updating the live tunnel in place keeps that behavior local to the affected crypto state and avoids rebuilding the whole peer object.

## Scope

This change is limited to the library peer-update path.

The UAPI `Set` path already removes and recreates peers, so its behavior is unchanged.

## Tests

This PR adds regression coverage for the affected paths:

- `modify_peer_updates_live_preshared_key`
- `update_peer_updates_live_preshared_key`
- `set_preshared_key_invalidates_existing_sessions`

The new tests verify that:

- changing the PSK through `modify_peer()` or `update_peer()` affects the live handshake state
- previously established sessions do not survive a PSK change
- the next exchange starts from a fresh handshake under the new PSK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/124)
<!-- Reviewable:end -->
