### PR TITLE
feature gate native socket implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buffers. New packet buffers will be allocated lazily as required when
   `PacketBufPool::get` is called.
 
+### Changed
+- Hide native UDP socket impls behind new `socket` feature.
+
 ### Fixed
 - Keep IPv4 fragments for different protocols in separate reassembly buffers.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
  "tracing",
  "tun",
  "typed-builder",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "x25519-dalek",
  "zerocopy",
 ]
@@ -1064,9 +1064,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -59,9 +59,9 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rand_core = { workspace = true, features = ["getrandom"] }
 ring = { workspace = true, optional = true }
-socket2 = { workspace = true, features = ["all"] }
+socket2 = { workspace = true, features = ["all"], optional = true }
 thiserror = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "io-util"] }
 tun = { workspace = true, default-features = false, features = ["async"], optional = true }
 typed-builder = { workspace = true }
 x25519-dalek = { workspace = true, features = [
@@ -113,7 +113,8 @@ aws-lc-rs = ["dep:aws-lc-rs"]
 # Add non-compliant UAPI support for DAITA.
 # See `UAPI.md` for details.
 daita-uapi = ["daita"]
-device = ["thiserror"]
+device = ["thiserror", "tokio/net", "socket"]
+socket = ["dep:socket2", "tokio/net"]
 pcap = ["dep:pcap-file"]
 tun = ["dep:tun", "thiserror"]
 # UDP GRO appears to be broken on Windows.

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -59,9 +59,9 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rand_core = { workspace = true, features = ["getrandom"] }
 ring = { workspace = true, optional = true }
-socket2 = { workspace = true, features = ["all"] }
+socket2 = { workspace = true, features = ["all"], optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "io-util"] }
 tokio-util = { version = "0.7.18", default-features = false }
 tracing = { workspace = true }
 tun = { workspace = true, default-features = false, features = ["async"], optional = true }
@@ -115,7 +115,8 @@ aws-lc-rs = ["dep:aws-lc-rs"]
 # Add non-compliant UAPI support for DAITA.
 # See `UAPI.md` for details.
 daita-uapi = ["daita"]
-device = []
+device = ["tokio/net", "socket"]
+socket = ["dep:socket2", "tokio/net"]
 pcap = ["dep:pcap-file"]
 tun = ["dep:tun"]
 # UDP GRO appears to be broken on Windows.

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -24,6 +24,7 @@ use crate::packet::{Packet, PacketBufPool};
 
 pub mod buffer;
 pub mod channel;
+#[cfg(feature = "socket")]
 pub mod socket;
 
 /// An abstraction of `UdpSocket::bind`.

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -11,8 +11,9 @@
 
 //! Trait abstractions for UDP sockets.
 //!
-//! [`socket`] contains implementation for actual UDP sockets.
-//! [`channel`] contains implementation for tokio-based channels.
+//! - [`socket`] contains implementation for actual UDP sockets.
+//! - [`channel`] contains implementation for tokio-based channels.
+#![cfg_attr(not(feature = "socket"), expect(rustdoc::broken_intra_doc_links))]
 
 use std::{
     future::Future,
@@ -165,6 +166,10 @@ pub trait UdpSend: Send + Sync + Clone {
     /// Get the port in use, if any.
     ///
     /// This is applicable to UDP sockets, i.e. [`tokio::net::UdpSocket`].
+    #[cfg_attr(
+        not(any(feature = "socket", feature = "tun")),
+        expect(rustdoc::broken_intra_doc_links)
+    )]
     fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
         Ok(None)
     }
@@ -173,6 +178,10 @@ pub trait UdpSend: Send + Sync + Clone {
     ///
     /// This is applicable to UDP sockets, i.e. [`tokio::net::UdpSocket`].
     #[cfg(target_os = "linux")]
+    #[cfg_attr(
+        not(any(feature = "socket", feature = "tun")),
+        expect(rustdoc::broken_intra_doc_links)
+    )]
     fn set_fwmark(&self, _mark: u32) -> io::Result<()> {
         Ok(())
     }

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -178,21 +178,6 @@ pub trait UdpSend: Send + Sync + Clone {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-fn check_send_max_number_of_packets(
-    max_number_of_packets: usize,
-    packets: &[(Packet, SocketAddr)],
-) -> io::Result<()> {
-    debug_assert!(packets.len() <= max_number_of_packets);
-    if packets.len() > max_number_of_packets {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("send_many_to: Number of packets may not exceed {max_number_of_packets}"),
-        ));
-    }
-    Ok(())
-}
-
 async fn generic_send_many_to<U: UdpSend>(
     transport: &U,
     packets: &mut Vec<(Packet, SocketAddr)>,

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -25,6 +25,7 @@ use crate::packet::{Packet, PacketBufPool};
 #[cfg(feature = "device")]
 pub(crate) mod buffer;
 pub mod channel;
+#[cfg(feature = "socket")]
 pub mod socket;
 
 /// An abstraction of `UdpSocket::bind`.

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -21,7 +21,10 @@ use tokio::io::Interest;
 
 use crate::{
     packet::Packet,
-    udp::{UdpSend, check_send_max_number_of_packets, socket::UdpSocket},
+    udp::{
+        UdpSend,
+        socket::{UdpSocket, check_send_max_number_of_packets},
+    },
 };
 
 /// Max number of packets/messages for sendmmsg/recvmmsg

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -279,6 +279,21 @@ fn is_bind_retry_error(err: &io::Error) -> bool {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+fn check_send_max_number_of_packets(
+    max_number_of_packets: usize,
+    packets: &[(crate::packet::Packet, SocketAddr)],
+) -> io::Result<()> {
+    debug_assert!(packets.len() <= max_number_of_packets);
+    if packets.len() > max_number_of_packets {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("send_many_to: Number of packets may not exceed {max_number_of_packets}"),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/gotatun/src/udp/socket/windows.rs
+++ b/gotatun/src/udp/socket/windows.rs
@@ -23,7 +23,10 @@ use cmsg::Cmsg;
 
 use crate::{
     packet::{Packet, PacketBufPool},
-    udp::{UdpRecv, UdpSend, check_send_max_number_of_packets, socket::UdpSocket},
+    udp::{
+        UdpRecv, UdpSend,
+        socket::{UdpSocket, check_send_max_number_of_packets},
+    },
 };
 
 pub struct SendmmsgBuf {


### PR DESCRIPTION
Resolves #121.

As part of this, we also feature gate some things which the sockets implementation depends on, which are not depended on by the whole codebase. In particular, the `socket2` crate, and `tokio`'s `"net"` feature.

Open question: What actually should the feature be named?
I find myself a little partial to `native_sockets`, though this currently names it `socket`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/125)
<!-- Reviewable:end -->
