### PR TITLE
Add `jemalloc` feature for using jemalloc instead of default allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Enable doc_cfg feature for docs.rs.
   https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html
-- Add `mimalloc` as an optional, alternative memory allocator.
+- Add `mimalloc` and `jemalloc` as optional, alternative memory allocators.
 - Add `Decoder` trait for parsing and validating byte slices as packet types,
   with implementations for IPv4/v6/TCP/UDP
 - Add TCP packet types.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "libc",
  "mimalloc",
  "nix",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1870,6 +1871,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ring = "0.17.14"
 socket2 = "0.6.0"
 test-log = "0.2.19"
 thiserror = "1"
+tikv-jemallocator = { version = "0.6", default-features = false }
 tokio = "1.43.0"
 tokio-stream = "0.1.18"
 tracing = "0.1.40"

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -32,6 +32,7 @@ nix = { workspace = true, default-features = false, features = [
   "uio",
   "user",
 ] }
+tikv-jemallocator = { workspace = true, default-features = false, optional = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
@@ -50,6 +51,8 @@ tracing-subscriber = { workspace = true }
 default = ["aws-lc-rs"]
 # Use the `aws-lc-rs` crate as the AEAD backend. Default.
 aws-lc-rs = ["gotatun/aws-lc-rs"]
+# Use jemalloc as allocator instead of system default.
+jemalloc = ["dep:tikv-jemallocator"]
 # Use mimalloc as allocator instead of system default.
 mimalloc = ["dep:mimalloc"]
 # Use the `ring` crate as the AEAD backend. Combine with

--- a/gotatun-cli/README.md
+++ b/gotatun-cli/README.md
@@ -4,6 +4,8 @@
 `gotatun` uses the [system]'s default allocator by default, but other allocators may be enabled via features:
 
 - `mimalloc`: Uses [mi-malloc] as the global memory allocator.
+- `jemalloc`: Uses [jemalloc] as the global memory allocator (Currently not available for Windows).
 
 [system]: https://doc.rust-lang.org/std/alloc/struct.System.html
 [mi-malloc]: https://microsoft.github.io/mimalloc/
+[jemalloc]: https://github.com/jemalloc/jemalloc

--- a/gotatun-cli/src/allocator/mod.rs
+++ b/gotatun-cli/src/allocator/mod.rs
@@ -10,4 +10,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #[global_allocator]
+#[cfg(feature = "mimalloc")]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[global_allocator]
+#[cfg(feature = "jemalloc")]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/gotatun-cli/src/main.rs
+++ b/gotatun-cli/src/main.rs
@@ -11,7 +11,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Common imports that are used on both platforms
-#[cfg(feature = "mimalloc")]
+
+// Only use an alternative allocator if one is explicitly chosen (i.e. not when compiling with
+// 'all-features').
+#[cfg(all(
+    any(feature = "mimalloc", feature = "jemalloc"),
+    not(all(feature = "mimalloc", feature = "jemalloc"))
+))]
 mod allocator;
 
 // Unix implementation


### PR DESCRIPTION
This PR builds on top of https://github.com/mullvad/gotatun/pull/27 and provides the `jemalloc` feature to use [jemalloc](https://github.com/tikv/jemallocator) as the global allocator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/126)
<!-- Reviewable:end -->
