### PR TITLE
Handle (some) irrecoverable errors on buffered tun read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Make tunnel stats counters more consistent with other WG implementations.
 
+#### Windows
+- Stop tunnel if WinTun read fails due to unexpected EOF.
+
 ### Security
 - Include source port in cookie MAC input. The WireGuard whitepaper states that the cookie
   should be computed using the remote endpoint's address, being both the IP and port.

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -11,7 +11,11 @@
 
 //! Generic buffered IP send and receive implementations.
 
-use std::{io, sync::Arc, time::Duration};
+use std::{
+    io::{self, ErrorKind},
+    sync::Arc,
+    time::Duration,
+};
 
 use crate::{
     packet::{Ip, Packet, PacketBufPool},
@@ -116,8 +120,10 @@ impl<I: IpRecv> BufferedIpRecv<I> {
                     }
                     Err(e) => {
                         log::error!("Error receiving IP packet: {e}");
-                        // exit?
-                        continue;
+                        match e.kind() {
+                            ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe => return,
+                            _ => (),
+                        }
                     }
                 }
             }


### PR DESCRIPTION
On at least Windows, reading from the tunnel can fail terminally for a bunch of reasons, e.g. if the tunnel goes down. See `WintunReceivePacket`: https://github.com/WireGuard/wintun/blob/ec0a6b98456fe1ba52567bb2add4bbf5f64315a1/api/session.c#L174-L222

Previously I just received a flood of these logs as we did not give up when this occurred:

```
[2026-04-09 12:48:37.953] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
[2026-04-09 12:48:37.953] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
[2026-04-09 12:48:37.953] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/127)
<!-- Reviewable:end -->
