### PR TITLE
Detect when TUN device is deleted and shut down gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Make tunnel stats counters more consistent with other WG implementations.
+- Exit gracefully when TUN device is deleted externally.
 
 ### Security
 - Include source port in cookie MAC input. The WireGuard whitepaper states that the cookie

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -52,6 +52,10 @@ impl BufferedIpSend {
 
             while let Some(packet) = rx.recv().await {
                 if let Err(e) = inner.send(packet).await {
+                    if is_fatal_tun_error(&e) {
+                        log::error!("TUN device was deleted, shutting down: {e}");
+                        break;
+                    }
                     log::error!("Error sending IP packet: {e}");
                 }
             }
@@ -115,9 +119,11 @@ impl<I: IpRecv> BufferedIpRecv<I> {
                         }
                     }
                     Err(e) => {
+                        if is_fatal_tun_error(&e) {
+                            log::error!("TUN device was deleted, shutting down: {e}");
+                            break;
+                        }
                         log::error!("Error receiving IP packet: {e}");
-                        // exit?
-                        continue;
                     }
                 }
             }
@@ -153,4 +159,24 @@ impl<I: IpRecv> IpRecv for BufferedIpRecv<I> {
     fn mtu(&self) -> MtuWatcher {
         self.mtu.clone()
     }
+}
+
+/// Checks if an I/O error indicates the TUN device has been deleted or is unusable.
+fn is_fatal_tun_error(err: &io::Error) -> bool {
+    #[cfg(target_os = "linux")]
+    if matches!(
+        err.raw_os_error(),
+        Some(libc::EBADF) | Some(libc::EBADFD) | Some(libc::ENODEV)
+    ) {
+        return true;
+    }
+
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound
+            | io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::InvalidData
+            | io::ErrorKind::InvalidInput
+    )
 }


### PR DESCRIPTION
When the TUN device is deleted externally (e.g. via 'ip link del'), gotatun now detects this and shuts down gracefully instead of continuously logging errors about the bad file descriptor.

Fixes #114

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/128)
<!-- Reviewable:end -->
