### PR TITLE
Add method on Device to notify on fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ring` can opt in by building with `--no-default-features --features ring`.
 - Make the `ring` dependency optional, gated behind the new `ring` feature.
 
+### Removed
+- Remove `tun::buffer` and `udp::buffer` modules.
+- `Device` is no longer `Clone`.
+
 ### Fixed
 - Make tunnel stats counters more consistent with other WG implementations.
 - Exit gracefully when TUN device is deleted externally.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "aead",
  "aws-lc-rs",
@@ -941,14 +941,14 @@ dependencies = [
  "tokio-util",
  "tun",
  "typed-builder",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "x25519-dalek",
  "zerocopy",
 ]
 
 [[package]]
 name = "gotatun-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "clap 3.2.25",
  "daemonize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tun",
  "typed-builder",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ either = "1.15.0"
 etherparse = "0.13"
 eyre = "0.6.12"
 futures = "0.3.31"
-gotatun = { path = "./gotatun", version = "0.5.1", default-features = false }
+gotatun = { path = "./gotatun", version = "0.6.0", default-features = false }
 hex = "0.4.3"
 hmac = "0.12.1"
 ip_network = "0.4.1"

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotatun-cli"
-version = "0.5.1"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gotatun-cli/src/unix/mod.rs
+++ b/gotatun-cli/src/unix/mod.rs
@@ -22,7 +22,7 @@ use std::os::unix::net::UnixDatagram;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use tokio::signal::unix::{SignalKind, signal};
-use tracing::{Level, info};
+use tracing::{Level, error, info};
 
 mod drop_privileges;
 
@@ -173,11 +173,12 @@ fn with_tokio_runtime(f: impl Future<Output = Result<()>>) -> Result<()> {
     rt.block_on(f)
 }
 
-async fn wait_for_shutdown(device: Device<DefaultDeviceTransports>) {
+async fn wait_for_shutdown(mut device: Device<DefaultDeviceTransports>) {
     let mut sigint = signal(SignalKind::interrupt()).expect("Failed to set up SIGINT handler");
     let mut sigterm = signal(SignalKind::terminate()).expect("Failed to set up SIGTERM handler");
 
     tokio::select! {
+        _ = device.wait() => error!("An error occured. Shutting down."),
         _ = sigint.recv() => info!("SIGINT received"),
         _ = sigterm.recv() => info!("SIGTERM received"),
     }

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -62,6 +62,7 @@ ring = { workspace = true, optional = true }
 socket2 = { workspace = true, features = ["all"] }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "net", "io-util"] }
+tokio-util = { version = "0.7.18", default-features = false }
 tun = { workspace = true, default-features = false, features = ["async"], optional = true }
 typed-builder = { workspace = true }
 x25519-dalek = { workspace = true, features = [

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gotatun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.5.1"
+version = "0.6.0"
 authors.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, watch};
 use x25519_dalek::StaticSecret;
 
 use crate::device::Error;
@@ -255,7 +255,10 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
             rate_limiter: None,
             port: self.port,
             connection: None,
+            fatal_error: watch::Sender::new(None),
         };
+
+        let fatal_error = state.fatal_error.subscribe();
 
         if let Some(private_key) = self.private_key {
             let _ = state.set_key(private_key).await;
@@ -279,6 +282,6 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
             Connection::set_up(inner.clone()).await?;
         }
 
-        Ok(Device { inner })
+        Ok(Device { inner, fatal_error })
     }
 }

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -43,7 +43,6 @@ use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::{Tunn, TunnResult};
 use crate::packet::{PacketBufPool, WgKind};
 use crate::task::Task;
-use crate::tun::buffer::{BufferedIpRecv, BufferedIpSend};
 use crate::tun::{IpRecv, IpSend, MtuWatcher};
 use crate::udp::buffer::{BufferedUdpReceive, BufferedUdpSend};
 use crate::udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams};
@@ -162,9 +161,13 @@ impl<T: DeviceTransports> Connection<T> {
         }
 
         let (udp4_tx, udp4_rx, udp6_tx, udp6_rx) = device.open_listen_socket().await?;
-        let buffered_ip_rx =
-            BufferedIpRecv::new(MAX_PACKET_BUFS, pool.clone(), Arc::clone(&device.tun_rx)).await;
-        let buffered_ip_tx = BufferedIpSend::new(MAX_PACKET_BUFS, Arc::clone(&device.tun_tx));
+        let (buffered_ip_tx, buffered_ip_rx) = crate::tun::buffer::channel(
+            MAX_PACKET_BUFS,
+            pool.clone(),
+            Arc::clone(&device.tun_tx),
+            Arc::clone(&device.tun_rx),
+        )
+        .await;
 
         let buffered_udp_tx_v4 = BufferedUdpSend::new(MAX_PACKET_BUFS, udp4_tx.clone());
         let buffered_udp_tx_v6 = BufferedUdpSend::new(MAX_PACKET_BUFS, udp6_tx.clone());

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -27,6 +27,7 @@ pub mod uapi;
 
 use crate::noise::index_table::IndexTable;
 use builder::Nul;
+use futures::TryFutureExt;
 use std::collections::HashMap;
 use std::io::{self};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
@@ -34,8 +35,8 @@ use std::ops::BitOrAssign;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tokio::join;
-use tokio::sync::Mutex;
 use tokio::sync::RwLock;
+use tokio::sync::{Mutex, watch};
 
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
@@ -89,6 +90,7 @@ pub enum Error {
 #[derive(Clone)]
 pub struct Device<T: DeviceTransports> {
     inner: Arc<RwLock<DeviceState<T>>>,
+    fatal_error: watch::Receiver<Option<Error>>,
 }
 
 /// Entry point for building a [`Device`].
@@ -129,6 +131,10 @@ pub(crate) struct DeviceState<T: DeviceTransports> {
 
     /// The task that responds to API requests.
     api: Option<Task>,
+
+    /// If an unrecoverable error occurs (such as the TUN device being deleted),
+    /// it will be stored here and propagated to all [`Device`] handles.
+    fatal_error: watch::Sender<Option<Error>>,
 }
 
 pub(crate) struct Connection<T: DeviceTransports> {
@@ -192,6 +198,17 @@ impl<T: DeviceTransports> Connection<T> {
             .await?;
         }
 
+        let fatal_error = device.fatal_error.clone();
+        let register_fatal_error = move |e| {
+            fatal_error.send_if_modified(|option| {
+                let has_error = option.is_some();
+                if !has_error {
+                    *option = Some(e);
+                }
+                !has_error
+            })
+        };
+
         // Start device tasks
         let outgoing = Task::spawn(
             "handle_outgoing",
@@ -201,7 +218,8 @@ impl<T: DeviceTransports> Connection<T> {
                 buffered_udp_tx_v4.clone(),
                 buffered_udp_tx_v6.clone(),
                 pool.clone(),
-            ),
+            )
+            .map_err(register_fatal_error.clone()),
         );
         let timers = Task::spawn(
             "handle_timers",
@@ -211,7 +229,6 @@ impl<T: DeviceTransports> Connection<T> {
                 buffered_udp_tx_v6.clone(),
             ),
         );
-
         let incoming_ipv4 = Task::spawn(
             "handle_incoming ipv4",
             DeviceState::handle_incoming(
@@ -220,7 +237,8 @@ impl<T: DeviceTransports> Connection<T> {
                 buffered_udp_tx_v4,
                 buffered_udp_rx_v4,
                 pool.clone(),
-            ),
+            )
+            .map_err(register_fatal_error.clone()),
         );
         let incoming_ipv6 = Task::spawn(
             "handle_incoming ipv6",
@@ -230,7 +248,8 @@ impl<T: DeviceTransports> Connection<T> {
                 buffered_udp_tx_v6,
                 buffered_udp_rx_v6,
                 pool.clone(),
-            ),
+            )
+            .map_err(register_fatal_error.clone()),
         );
 
         debug_assert!(device.connection.is_none());
@@ -266,6 +285,14 @@ impl<T: DeviceTransports> Device<T> {
         if let Some(connection) = device.connection.take() {
             connection.stop().await;
         }
+    }
+
+    /// Wait until an unrecoverable error occurs.
+    pub async fn wait(&mut self) {
+        self.fatal_error
+            .wait_for(|err| err.is_some())
+            .await
+            .expect("Sender will not be dropped while Self exists");
     }
 }
 
@@ -664,9 +691,9 @@ impl<T: DeviceTransports> DeviceState<T> {
                         continue;
                     }
 
-                    if let Err(_err) = tun_tx.send(packet).await {
+                    if let Err(e) = tun_tx.send(packet).await {
                         log::trace!("buffered_tun_send.send failed");
-                        break;
+                        return Err(Error::IoError(e));
                     }
                 }
             }
@@ -682,10 +709,10 @@ impl<T: DeviceTransports> DeviceState<T> {
         udp4: impl UdpSend,
         udp6: impl UdpSend,
         mut packet_pool: PacketBufPool,
-    ) {
+    ) -> Result<(), Error> {
         let mut tun_mtu = {
             let Some(device) = device.upgrade() else {
-                return;
+                return Ok(());
             };
             let device = device.read().await;
             device.tun_rx_mtu.clone()
@@ -696,7 +723,7 @@ impl<T: DeviceTransports> DeviceState<T> {
                 Ok(packets) => packets,
                 Err(e) => {
                     log::error!("Unexpected error on tun interface: {e:?}");
-                    break;
+                    return Err(Error::IoError(e));
                 }
             };
 
@@ -707,7 +734,7 @@ impl<T: DeviceTransports> DeviceState<T> {
                 };
 
                 let Some(device_arc) = device.upgrade() else {
-                    return;
+                    return Ok(());
                 };
 
                 let device_guard = device_arc.read().await;

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -87,7 +87,6 @@ pub enum Error {
 }
 
 /// A reference-counted handle to a WireGuard device.
-#[derive(Clone)]
 pub struct Device<T: DeviceTransports> {
     inner: Arc<RwLock<DeviceState<T>>>,
     fatal_error: watch::Receiver<Option<Error>>,

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -177,12 +177,8 @@ impl<T: DeviceTransports> Connection<T> {
         let buffered_udp_tx_v4 = BufferedUdpSend::new(MAX_PACKET_BUFS, udp4_tx.clone());
         let buffered_udp_tx_v6 = BufferedUdpSend::new(MAX_PACKET_BUFS, udp6_tx.clone());
 
-        let buffered_udp_rx_v4 = BufferedUdpReceive::new::<
-            <T::UdpTransportFactory as UdpTransportFactory>::RecvV4,
-        >(MAX_PACKET_BUFS, udp4_rx, pool.clone());
-        let buffered_udp_rx_v6 = BufferedUdpReceive::new::<
-            <T::UdpTransportFactory as UdpTransportFactory>::RecvV6,
-        >(MAX_PACKET_BUFS, udp6_rx, pool.clone());
+        let buffered_udp_rx_v4 = BufferedUdpReceive::new(MAX_PACKET_BUFS, udp4_rx, pool.clone());
+        let buffered_udp_rx_v6 = BufferedUdpReceive::new(MAX_PACKET_BUFS, udp6_rx, pool.clone());
 
         // Start DAITA/hooks tasks
         #[cfg(feature = "daita")]

--- a/gotatun/src/task.rs
+++ b/gotatun/src/task.rs
@@ -48,6 +48,7 @@ where
 }
 
 impl Task {
+    #[cfg(any(feature = "device", feature = "tun"))]
     #[track_caller]
     pub fn spawn<Fut, O>(name: &'static str, fut: Fut) -> Self
     where

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -76,7 +76,7 @@ impl BufferedIpSend {
             while let Some(packet) = rx.recv().await {
                 if let Err(e) = inner.send(packet).await {
                     if is_fatal_tun_error(&e) {
-                        log::error!("TUN device was deleted, shutting down: {e}");
+                        log::error!("TUN device was deleted: {e}");
                         break;
                     }
                     log::error!("Error sending IP packet: {e}");
@@ -156,7 +156,7 @@ impl<I: IpRecv> BufferedIpRecv<I> {
                     }
                     Err(e) => {
                         if is_fatal_tun_error(&e) {
-                            log::error!("TUN device was deleted, shutting down: {e}");
+                            log::error!("TUN device was deleted: {e}");
                             break;
                         }
                         log::error!("Error receiving IP packet: {e}");

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -22,6 +22,27 @@ use tokio::{
     sync::{Mutex, mpsc},
     time::timeout,
 };
+use tokio_util::sync::CancellationToken;
+
+/// Create a pair of [`BufferedIpSend`] and [`BufferedIpRecv`] with `capacity`.
+///
+/// This takes an `Arc<Mutex<S>>` and `Arc<Mutex<R>>` because the inner `S` and `R` will be re-used
+/// after [BufferedIpSend] or [BufferedIpRecv] is dropped. We will take the mutex lock when this
+/// function is called, and hold onto it for the lifetime of the sender or receiver.
+///
+/// # Panics
+/// Panics if one of the locks is already taken.
+pub async fn channel<S: IpSend, R: IpRecv>(
+    capacity: usize,
+    pool: PacketBufPool,
+    send: Arc<Mutex<S>>,
+    recv: Arc<Mutex<R>>,
+) -> (BufferedIpSend, BufferedIpRecv<R>) {
+    let token = CancellationToken::new();
+    let buffer_send = BufferedIpSend::new(capacity, send, token.clone());
+    let buffer_recv = BufferedIpRecv::new(capacity, pool, recv, token).await;
+    (buffer_send, buffer_recv)
+}
 
 /// An [`IpSend`] that wraps another [`IpSend`] to provide buffering.
 ///
@@ -42,10 +63,12 @@ impl BufferedIpSend {
     ///
     /// # Panics
     /// Panics if the lock is already taken.
-    pub fn new<I: IpSend>(capacity: usize, inner: Arc<Mutex<I>>) -> Self {
+    fn new<I: IpSend>(capacity: usize, inner: Arc<Mutex<I>>, token: CancellationToken) -> Self {
         let (tx, mut rx) = mpsc::channel::<Packet<Ip>>(capacity);
 
-        let task = Task::spawn("buffered IP send", async move {
+        let drop_guard = token.clone().drop_guard();
+
+        let task = async move {
             let mut inner = timeout(Duration::from_secs(5), inner.lock())
                 .await
                 .expect("Deadlock on IpSend. There must be no more than one IpSend active at any given time.");
@@ -59,6 +82,12 @@ impl BufferedIpSend {
                     log::error!("Error sending IP packet: {e}");
                 }
             }
+
+            drop(drop_guard);
+        };
+
+        let task = Task::spawn("buffered IP send", async move {
+            token.run_until_cancelled_owned(task).await;
         });
 
         Self {
@@ -96,7 +125,12 @@ impl<I: IpRecv> BufferedIpRecv<I> {
     /// This takes an `Arc<Mutex<I>>` because the inner `I` will be re-used after [Self] is
     /// dropped. We will take the mutex lock when this function is called, and hold onto it for the
     /// lifetime of [Self]. Will panic if the lock is already taken.
-    pub async fn new(capacity: usize, mut pool: PacketBufPool, inner: Arc<Mutex<I>>) -> Self {
+    async fn new(
+        capacity: usize,
+        mut pool: PacketBufPool,
+        inner: Arc<Mutex<I>>,
+        token: CancellationToken,
+    ) -> Self {
         let (tx, rx) = mpsc::channel::<Packet<Ip>>(capacity);
 
         // We use a timeout instead of a try_lock().expect() because there may still be an old
@@ -108,7 +142,9 @@ impl<I: IpRecv> BufferedIpRecv<I> {
 
         let mtu = inner.mtu();
 
-        let task = Task::spawn("buffered IP recv", async move {
+        let drop_guard = token.clone().drop_guard();
+
+        let task = async move {
             loop {
                 match inner.recv(&mut pool).await {
                     Ok(packets) => {
@@ -127,6 +163,10 @@ impl<I: IpRecv> BufferedIpRecv<I> {
                     }
                 }
             }
+            drop(drop_guard);
+        };
+        let task = Task::spawn("buffered IP recv", async move {
+            token.run_until_cancelled_owned(task).await;
         });
 
         Self {

--- a/gotatun/src/tun/mod.rs
+++ b/gotatun/src/tun/mod.rs
@@ -19,7 +19,8 @@ use crate::packet::{Ip, Packet, PacketBufPool};
 use std::future::{Future, pending};
 use std::io;
 
-pub mod buffer;
+#[cfg(feature = "device")]
+pub(crate) mod buffer;
 pub mod channel;
 
 #[cfg(feature = "pcap")]

--- a/gotatun/src/udp/buffer.rs
+++ b/gotatun/src/udp/buffer.rs
@@ -125,7 +125,7 @@ pub struct BufferedUdpReceive {
 
 impl BufferedUdpReceive {
     /// Wrap a [`UdpRecv`] into a [`BufferedUdpReceive`] with `capacity`.
-    pub fn new<U: UdpRecv + 'static>(
+    pub fn new(
         capacity: usize,
         mut udp_rx: impl UdpRecv + 'static,
         mut recv_pool: PacketBufPool,

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -22,7 +22,8 @@ use std::{
 
 use crate::packet::{Packet, PacketBufPool};
 
-pub mod buffer;
+#[cfg(feature = "device")]
+pub(crate) mod buffer;
 pub mod channel;
 pub mod socket;
 


### PR DESCRIPTION
Add `Device::wait`. This method waits until the device encounter a fatal error, informing the Device owner to tear it down.

Related: #128. When the TUN device is removed and either receiver or sender is killed, make sure both tasks are aborted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/129)
<!-- Reviewable:end -->
