### PR TITLE
Use `jemalloc` default memory allocator in `gotatun-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rename `CheckedPayload` trait to `PoD`.
 
+### Changed
+- Use `jemalloc` default memory allocator in `gotatun-cli`.
+
 
 ## [0.6.0] - 2026-04-30
 ### Added

--- a/gotatun-cli/Cargo.toml
+++ b/gotatun-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 mimalloc = { workspace = true, default-features = false, optional = true }
+tikv-jemallocator = { workspace = true, default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 clap = { workspace = true, features = ["derive", "env"] }
@@ -32,7 +33,6 @@ nix = { workspace = true, default-features = false, features = [
   "uio",
   "user",
 ] }
-tikv-jemallocator = { workspace = true, default-features = false, optional = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
@@ -48,7 +48,7 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["aws-lc-rs"]
+default = ["aws-lc-rs", "jemalloc"]
 # Use the `aws-lc-rs` crate as the AEAD backend. Default.
 aws-lc-rs = ["gotatun/aws-lc-rs"]
 # Use jemalloc as allocator instead of system default.


### PR DESCRIPTION
We've observed a lot of fragmentation with glibc's allocator on Linux, which is remedied by switching to an alternative allocator. This PR switch to jemalloc, which mirrors [the decision taken downstream in the Mullvad VPN app](https://github.com/mullvad/mullvadvpn-app/pull/10316).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/133)
<!-- Reviewable:end -->
