### PR TITLE
Allow UDP buffer sizes to be configured via `DeviceBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with implementations for IPv4/v6/TCP/UDP
 - Add TCP packet types.
 - Add more function for computing internet checksums.
+- Allow UDP send/recv buffer sizes (`SO_SNDBUF`/`SO_RCVBUF`) to be configured via
+  `DeviceBuilder::udp_send_buffer_size` and `DeviceBuilder::udp_recv_buffer_size`.
 
 ### Changed
 - Rename `CheckedPayload` trait to `PoD`.
+- `gotatun::udp::socket::UdpSocketFactory` now uses operating system default values for `SO_SNDBUF`
+  and `SO_RCVBUF` (instead of forcibly adjusting them to 7 MB each).
 
 
 ## [0.6.0] - 2026-04-30

--- a/gotatun-cli/src/unix/mod.rs
+++ b/gotatun-cli/src/unix/mod.rs
@@ -214,6 +214,10 @@ async fn setup_device(args: Args) -> eyre::Result<Device<DefaultDeviceTransports
     let dev = DeviceBuilder::new()
         .with_uapi(uapi)
         .with_default_udp()
+        // Use 7MB socket buffers. Empirically this seems to be more perfomant than the default OS
+        // socket buffer sizes.
+        .udp_recv_buffer_size(7 * 1024 * 1024)
+        .udp_send_buffer_size(7 * 1024 * 1024)
         .with_ip(tun)
         .build()
         .await

--- a/gotatun-cli/src/windows/mod.rs
+++ b/gotatun-cli/src/windows/mod.rs
@@ -111,6 +111,10 @@ async fn setup_device(args: &Args) -> eyre::Result<Device<DefaultDeviceTransport
     let dev = DeviceBuilder::new()
         .with_uapi(uapi)
         .with_default_udp()
+        // Use 7MB socket buffers. Empirically this seems to be more perfomant than the default OS
+        // socket buffer sizes.
+        .udp_recv_buffer_size(7 * 1024 * 1024)
+        .udp_send_buffer_size(7 * 1024 * 1024)
         .with_ip(tun)
         .build()
         .await

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -90,7 +90,7 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
     /// Create a WireGuard device that reads/writes incoming/outgoing packets using a UDP socket.
     /// This is the conventional device kind.
     pub fn with_default_udp(self) -> DeviceBuilder<UdpSocketFactory, X, Y> {
-        self.with_udp(UdpSocketFactory)
+        self.with_udp(UdpSocketFactory::default())
     }
 
     /// Create a WireGuard device with a custom [`UdpTransportFactory`].
@@ -109,6 +109,26 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
+    }
+}
+
+impl<X, Y> DeviceBuilder<UdpSocketFactory, X, Y> {
+    /// Specify the `SO_RCVBUF` argument to the [`UdpTransportFactory`].
+    ///
+    /// Changes the size of the operating system's receive buffer associated
+    /// with the socket.
+    pub const fn udp_recv_buffer_size(mut self, recv_buffer_size: usize) -> Self {
+        self.udp.recv_buffer_size = Some(recv_buffer_size);
+        self
+    }
+
+    /// Specify the `SO_SNDBUF` argument to the [`UdpTransportFactory`].
+    ///
+    /// Changes the size of the operating system's send buffer associated with
+    /// the socket.
+    pub const fn udp_send_buffer_size(mut self, send_buffer_size: usize) -> Self {
+        self.udp.send_buffer_size = Some(send_buffer_size);
+        self
     }
 }
 

--- a/gotatun/src/device/integration_tests/mod.rs
+++ b/gotatun/src/device/integration_tests/mod.rs
@@ -285,7 +285,7 @@ mod tests {
             let device_builder = DeviceBuilder::new()
                 .create_tun(&tun_name)
                 .unwrap()
-                .with_udp(UdpSocketFactory)
+                .with_udp(UdpSocketFactory::default())
                 .with_uapi(uapi);
 
             let _device = device_builder.build().await.unwrap();

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -261,15 +261,18 @@ mod gro {
     mod tests {
         use super::UdpSocket;
         use crate::packet::PacketBufPool;
+        use crate::udp::socket::SockOpt;
         use crate::udp::{UdpRecv, UdpSend};
         use std::net::Ipv6Addr;
         use std::time::Duration;
 
         #[tokio::test]
         async fn recv_many_from_preserves_ipv6_source_addr() {
-            let mut receiver = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into()).unwrap();
+            let mut receiver =
+                UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
             receiver.enable_udp_gro().ok();
-            let sender = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into()).unwrap();
+            let sender =
+                UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
 
             let recv_addr = receiver.local_addr().unwrap();
             let sender_addr = sender.local_addr().unwrap();

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -21,9 +21,6 @@ use std::{
 
 use super::{UdpRecv, UdpTransportFactory, UdpTransportFactoryParams};
 
-#[cfg(target_os = "linux")]
-use super::UdpSend;
-
 /// Implementations of [`super::UdpSend`]/[`super::UdpRecv`] for all targets
 #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows")))]
 mod generic;
@@ -37,10 +34,13 @@ mod linux;
 mod windows;
 
 /// An implementation of [`UdpTransportFactory`] for regular UDP sockets. This provides `bind`.
-pub struct UdpSocketFactory;
-
-const UDP_RECV_BUFFER_SIZE: usize = 7 * 1024 * 1024;
-const UDP_SEND_BUFFER_SIZE: usize = 7 * 1024 * 1024;
+#[derive(Debug, Default)]
+pub struct UdpSocketFactory {
+    /// If `Some`, set `SO_RCVBUF` on the socket.
+    pub recv_buffer_size: Option<usize>,
+    /// If `Some`, set `SO_SNDBUF` on the socket.
+    pub send_buffer_size: Option<usize>,
+}
 
 impl UdpTransportFactory for UdpSocketFactory {
     type SendV4 = UdpSocket;
@@ -52,13 +52,14 @@ impl UdpTransportFactory for UdpSocketFactory {
         &mut self,
         params: &UdpTransportFactoryParams,
     ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
-        let (udp_v4, udp_v6) = bind_sockets(params.addr_v4, params.addr_v6, params.port)?;
+        let opts = SockOpt {
+            #[cfg(target_os = "linux")]
+            fwmark: params.fwmark,
+            recv_buffer_size: self.recv_buffer_size,
+            send_buffer_size: self.send_buffer_size,
+        };
 
-        #[cfg(target_os = "linux")]
-        if let Some(mark) = params.fwmark {
-            udp_v4.set_fwmark(mark)?;
-            udp_v6.set_fwmark(mark)?;
-        }
+        let (udp_v4, udp_v6) = bind_sockets(params.addr_v4, params.addr_v6, params.port, opts)?;
 
         if let Err(err) = udp_v4.enable_udp_gro() {
             log::warn!("Failed to enable UDP GRO for IPv4 socket: {err}");
@@ -77,14 +78,26 @@ pub struct UdpSocket {
     inner: Arc<tokio::net::UdpSocket>,
 }
 
+/// Options set on the socket created by [`UdpSocket::bind`].
+#[derive(Copy, Clone, Debug, Default)]
+pub struct SockOpt {
+    /// If `Some`, set `fwmark` on the socket.
+    #[cfg(target_os = "linux")]
+    pub fwmark: Option<u32>,
+    /// If `Some`, set `SO_RCVBUF` on the socket.
+    pub recv_buffer_size: Option<usize>,
+    /// If `Some`, set `SO_SNDBUF` on the socket.
+    pub send_buffer_size: Option<usize>,
+}
+
 impl UdpSocket {
     /// Create a UDP socket and bind it to `addr`.
     ///
     /// This also configures the following socket options:
     /// - `nonblocking`, to work with [`tokio`].
     /// - `reuse_address`, to allow IPv6 and IPv4 sockets to be bound to the same port.
-    /// - `{recv,send}_buffer_size`, for better performance.
-    pub fn bind(addr: SocketAddr) -> io::Result<Self> {
+    /// - `{recv,send}_buffer_size`, for better performance. See [`SockOpt`].
+    pub fn bind(addr: SocketAddr, opts: SockOpt) -> io::Result<Self> {
         let domain = match addr {
             SocketAddr::V4(..) => socket2::Domain::IPV4,
             SocketAddr::V6(..) => socket2::Domain::IPV6,
@@ -95,9 +108,31 @@ impl UdpSocket {
             socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
         udp_sock.set_nonblocking(true)?;
         udp_sock.set_reuse_address(true)?;
-        udp_sock.set_recv_buffer_size(UDP_RECV_BUFFER_SIZE)?;
-        udp_sock.set_send_buffer_size(UDP_SEND_BUFFER_SIZE)?;
-        // TODO: set forced buffer sizes?
+        #[cfg(target_os = "linux")]
+        if let Some(mark) = opts.fwmark {
+            udp_sock.set_mark(mark)?;
+        }
+        // Failing to set buffer sizes is not a fatal error - the tunnel will most likely work just
+        // fine, even if not as performant as possible. In that case it is still a good idea to
+        // tweak the buffer sizes.
+        if let Some(recv_buffer_size) = opts.recv_buffer_size {
+            if let Err(err) = udp_sock.set_recv_buffer_size(recv_buffer_size) {
+                if cfg!(debug_assertions) {
+                    return Err(err);
+                } else {
+                    log::error!("Failed to change UDP socket receive buffer size: {err}");
+                }
+            }
+        }
+        if let Some(send_buffer_size) = opts.send_buffer_size {
+            if let Err(err) = udp_sock.set_send_buffer_size(send_buffer_size) {
+                if cfg!(debug_assertions) {
+                    return Err(err);
+                } else {
+                    log::error!("Failed to change UDP socket send buffer size: {err}");
+                }
+            }
+        }
 
         udp_sock.bind(&addr.into())?;
 
@@ -125,12 +160,13 @@ fn bind_sockets(
     addr_v4: Ipv4Addr,
     addr_v6: Ipv6Addr,
     port: u16,
+    opts: SockOpt,
 ) -> io::Result<(UdpSocket, UdpSocket)> {
-    let udp_v4 = UdpSocket::bind((addr_v4, port).into())?;
+    let udp_v4 = UdpSocket::bind((addr_v4, port).into(), opts)?;
     match port {
-        0 => bind_v6_with_retry(addr_v4, addr_v6, udp_v4),
+        0 => bind_v6_with_retry(addr_v4, addr_v6, udp_v4, opts),
         p => {
-            let udp_v6 = UdpSocket::bind((addr_v6, p).into())?;
+            let udp_v6 = UdpSocket::bind((addr_v6, p).into(), opts)?;
             Ok((udp_v4, udp_v6))
         }
     }
@@ -142,18 +178,19 @@ fn bind_v6_with_retry(
     addr_v4: Ipv4Addr,
     addr_v6: Ipv6Addr,
     mut udp_v4: UdpSocket,
+    opts: SockOpt,
 ) -> io::Result<(UdpSocket, UdpSocket)> {
     let mut port = UdpSocket::local_addr(&udp_v4)?.port();
     let mut retries = 0u32;
     let udp_v6 = loop {
-        match UdpSocket::bind((addr_v6, port).into()) {
+        match UdpSocket::bind((addr_v6, port).into(), opts) {
             Ok(sock) => break sock,
             Err(err) if is_bind_retry_error(&err) && retries < BIND_MAX_RETRIES => {
                 retries += 1;
                 log::debug!(
                     "IPv6 port {port} already in use, retrying ({retries}/{BIND_MAX_RETRIES})"
                 );
-                udp_v4 = UdpSocket::bind((addr_v4, 0).into())?;
+                udp_v4 = UdpSocket::bind((addr_v4, 0).into(), opts)?;
                 port = UdpSocket::local_addr(&udp_v4)?.port();
             }
             Err(err) => return Err(err),
@@ -212,14 +249,21 @@ mod tests {
             .port();
 
         // Pre-bind IPv4 to the blocked port (succeeds because the blocker is IPv6-only).
-        let udp_v4 =
-            UdpSocket::bind((Ipv4Addr::UNSPECIFIED, blocked_port).into()).expect("bind v4");
+        let udp_v4 = UdpSocket::bind(
+            (Ipv4Addr::UNSPECIFIED, blocked_port).into(),
+            SockOpt::default(),
+        )
+        .expect("bind v4");
 
         // This should fail to bind IPv6 to blocked_port,
         // then rebind both sockets to a new random port.
-        let (udp_v4, udp_v6) =
-            bind_v6_with_retry(Ipv4Addr::UNSPECIFIED, Ipv6Addr::UNSPECIFIED, udp_v4)
-                .expect("bind_v6_with_retry");
+        let (udp_v4, udp_v6) = bind_v6_with_retry(
+            Ipv4Addr::UNSPECIFIED,
+            Ipv6Addr::UNSPECIFIED,
+            udp_v4,
+            SockOpt::default(),
+        )
+        .expect("bind_v6_with_retry");
 
         let v4_port = udp_v4.local_addr().unwrap().port();
         let v6_port = udp_v6.local_addr().unwrap().port();


### PR DESCRIPTION
This PR adds `DeviceBuilder::udp_send_buffer_size` and `DeviceBuilder::udp_recv_buffer_size` for setting the `SO_SNDBUF` and `SO_RCVBUF` options on the UDP socket created with `UdpSocketFactory::bind`.

Open question: Is it preferable to separate the socket creation (where the socket options are set) from the actual bind? I.e. split current `UdpSocketFactory::bind` into two function, e.g. `UdpSocketFactory::create` + `UdpSocketFactory::bind`. It would allow us to keep the function signature of `bind` in line with [socket2::UdpSocket::bind](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.bind).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/134)
<!-- Reviewable:end -->
