### PR TITLE
Allow UDP buffer sizes to be configured via `DeviceBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow UDP send/recv buffer sizes (`SO_SNDBUF`/`SO_RCVBUF`) to be configured via
+  `DeviceBuilder::udp_send_buffer_size` and `DeviceBuilder::udp_recv_buffer_size`.
+
+### Changed
+- `gotatun::udp::socket::UdpSocketFactory` now uses operating system default values for `SO_SNDBUF`
+  and `SO_RCVBUF` (instead of forcibly adjusting them to 7 MB each).
 
 
 ## [0.6.0] - 2026-04-30

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -90,7 +90,7 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
     /// Create a WireGuard device that reads/writes incoming/outgoing packets using a UDP socket.
     /// This is the conventional device kind.
     pub fn with_default_udp(self) -> DeviceBuilder<UdpSocketFactory, X, Y> {
-        self.with_udp(UdpSocketFactory)
+        self.with_udp(UdpSocketFactory::default())
     }
 
     /// Create a WireGuard device with a custom [`UdpTransportFactory`].
@@ -109,6 +109,35 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
+    }
+}
+
+impl<X, Y> DeviceBuilder<UdpSocketFactory, X, Y> {
+    /// Specify the `SO_MARK` argument to the [`UdpTransportFactory`].
+    ///
+    /// You probably only want this when using [`with_default_udp`](Self::with_default_udp).
+    #[cfg(target_os = "linux")]
+    pub const fn with_fwmark(mut self, fwmark: u32) -> Self {
+        self.udp.opts.fwmark = Some(fwmark);
+        self
+    }
+
+    /// Specify the `SO_RCVBUF` argument to the [`UdpTransportFactory`].
+    ///
+    /// Changes the size of the operating system's receive buffer associated
+    /// with the socket.
+    pub const fn udp_recv_buffer_size(mut self, recv_buffer_size: usize) -> Self {
+        self.udp.opts.recv_buffer_size = Some(recv_buffer_size);
+        self
+    }
+
+    /// Specify the `SO_SNDBUF` argument to the [`UdpTransportFactory`].
+    ///
+    /// Changes the size of the operating system's send buffer associated with
+    /// the socket.
+    pub const fn udp_send_buffer_size(mut self, send_buffer_size: usize) -> Self {
+        self.udp.opts.send_buffer_size = Some(send_buffer_size);
+        self
     }
 }
 
@@ -211,15 +240,6 @@ impl<X, Y, Z> DeviceBuilder<X, Y, Z> {
     /// By default, the device uses [IndexTable::from_os_rng].
     pub fn with_index_table(mut self, index_table: IndexTable) -> Self {
         self.index_table = Some(index_table);
-        self
-    }
-
-    /// Specify the `SO_MARK` argument to the [`UdpTransportFactory`].
-    ///
-    /// You probably only want this when using [`with_default_udp`](Self::with_default_udp).
-    #[cfg(target_os = "linux")]
-    pub const fn with_fwmark(mut self, fwmark: u32) -> Self {
-        self.fwmark = Some(fwmark);
         self
     }
 }

--- a/gotatun/src/device/integration_tests/mod.rs
+++ b/gotatun/src/device/integration_tests/mod.rs
@@ -285,7 +285,7 @@ mod tests {
             let device_builder = DeviceBuilder::new()
                 .create_tun(&tun_name)
                 .unwrap()
-                .with_udp(UdpSocketFactory)
+                .with_udp(UdpSocketFactory::default())
                 .with_uapi(uapi);
 
             let _device = device_builder.build().await.unwrap();

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -411,8 +411,6 @@ impl<T: DeviceTransports> DeviceState<T> {
             addr_v4: Ipv4Addr::UNSPECIFIED,
             addr_v6: Ipv6Addr::UNSPECIFIED,
             port: self.port,
-            #[cfg(target_os = "linux")]
-            fwmark: self.fwmark,
         };
         let ((udp4_tx, udp4_rx), (udp6_tx, udp6_rx)) = self
             .udp_factory

--- a/gotatun/src/udp/mod.rs
+++ b/gotatun/src/udp/mod.rs
@@ -66,10 +66,6 @@ pub struct UdpTransportFactoryParams {
 
     /// The port to bind the UDP socket to.
     pub port: u16,
-
-    /// If `Some`, set `fwmark` on the socket.
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
 }
 
 /// An abstraction of `recv_from` for a UDP socket.

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -261,15 +261,18 @@ mod gro {
     mod tests {
         use super::UdpSocket;
         use crate::packet::PacketBufPool;
+        use crate::udp::socket::SockOpt;
         use crate::udp::{UdpRecv, UdpSend};
         use std::net::Ipv6Addr;
         use std::time::Duration;
 
         #[tokio::test]
         async fn recv_many_from_preserves_ipv6_source_addr() {
-            let mut receiver = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into()).unwrap();
+            let mut receiver =
+                UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
             receiver.enable_udp_gro().ok();
-            let sender = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into()).unwrap();
+            let sender =
+                UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
 
             let recv_addr = receiver.local_addr().unwrap();
             let sender_addr = sender.local_addr().unwrap();

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -21,9 +21,6 @@ use std::{
 
 use super::{UdpRecv, UdpTransportFactory, UdpTransportFactoryParams};
 
-#[cfg(target_os = "linux")]
-use super::UdpSend;
-
 /// Implementations of [`super::UdpSend`]/[`super::UdpRecv`] for all targets
 #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows")))]
 mod generic;
@@ -37,10 +34,11 @@ mod linux;
 mod windows;
 
 /// An implementation of [`UdpTransportFactory`] for regular UDP sockets. This provides `bind`.
-pub struct UdpSocketFactory;
-
-const UDP_RECV_BUFFER_SIZE: usize = 7 * 1024 * 1024;
-const UDP_SEND_BUFFER_SIZE: usize = 7 * 1024 * 1024;
+#[derive(Debug, Default)]
+pub struct UdpSocketFactory {
+    /// Additional socket options.
+    pub(crate) opts: SockOpt,
+}
 
 impl UdpTransportFactory for UdpSocketFactory {
     type SendV4 = UdpSocket;
@@ -52,13 +50,8 @@ impl UdpTransportFactory for UdpSocketFactory {
         &mut self,
         params: &UdpTransportFactoryParams,
     ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
-        let (udp_v4, udp_v6) = bind_sockets(params.addr_v4, params.addr_v6, params.port)?;
-
-        #[cfg(target_os = "linux")]
-        if let Some(mark) = params.fwmark {
-            udp_v4.set_fwmark(mark)?;
-            udp_v6.set_fwmark(mark)?;
-        }
+        let (udp_v4, udp_v6) =
+            bind_sockets(params.addr_v4, params.addr_v6, params.port, self.opts)?;
 
         if let Err(err) = udp_v4.enable_udp_gro() {
             log::warn!("Failed to enable UDP GRO for IPv4 socket: {err}");
@@ -77,14 +70,26 @@ pub struct UdpSocket {
     inner: Arc<tokio::net::UdpSocket>,
 }
 
+/// Options set on the socket created by [`UdpSocket::bind`].
+#[derive(Copy, Clone, Debug, Default)]
+pub struct SockOpt {
+    /// If `Some`, set `fwmark` on the socket.
+    #[cfg(target_os = "linux")]
+    pub fwmark: Option<u32>,
+    /// If `Some`, set `SO_RCVBUF` on the socket.
+    pub recv_buffer_size: Option<usize>,
+    /// If `Some`, set `SO_SNDBUF` on the socket.
+    pub send_buffer_size: Option<usize>,
+}
+
 impl UdpSocket {
     /// Create a UDP socket and bind it to `addr`.
     ///
     /// This also configures the following socket options:
     /// - `nonblocking`, to work with [`tokio`].
     /// - `reuse_address`, to allow IPv6 and IPv4 sockets to be bound to the same port.
-    /// - `{recv,send}_buffer_size`, for better performance.
-    pub fn bind(addr: SocketAddr) -> io::Result<Self> {
+    /// - `{recv,send}_buffer_size`, for better performance. See [`SockOpt`].
+    pub fn bind(addr: SocketAddr, opts: SockOpt) -> io::Result<Self> {
         let domain = match addr {
             SocketAddr::V4(..) => socket2::Domain::IPV4,
             SocketAddr::V6(..) => socket2::Domain::IPV6,
@@ -95,9 +100,31 @@ impl UdpSocket {
             socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
         udp_sock.set_nonblocking(true)?;
         udp_sock.set_reuse_address(true)?;
-        udp_sock.set_recv_buffer_size(UDP_RECV_BUFFER_SIZE)?;
-        udp_sock.set_send_buffer_size(UDP_SEND_BUFFER_SIZE)?;
-        // TODO: set forced buffer sizes?
+        #[cfg(target_os = "linux")]
+        if let Some(mark) = opts.fwmark {
+            udp_sock.set_mark(mark)?;
+        }
+        // Failing to set buffer sizes is not a fatal error - the tunnel will most likely work just
+        // fine, even if not as performant as possible. In that case it is still a good idea to
+        // tweak the buffer sizes.
+        if let Some(recv_buffer_size) = opts.recv_buffer_size {
+            if let Err(err) = udp_sock.set_recv_buffer_size(recv_buffer_size) {
+                if cfg!(debug_assertions) {
+                    return Err(err);
+                } else {
+                    log::error!("Failed to change UDP socket receive buffer size: {err}");
+                }
+            }
+        }
+        if let Some(send_buffer_size) = opts.send_buffer_size {
+            if let Err(err) = udp_sock.set_send_buffer_size(send_buffer_size) {
+                if cfg!(debug_assertions) {
+                    return Err(err);
+                } else {
+                    log::error!("Failed to change UDP socket send buffer size: {err}");
+                }
+            }
+        }
 
         udp_sock.bind(&addr.into())?;
 
@@ -125,12 +152,13 @@ fn bind_sockets(
     addr_v4: Ipv4Addr,
     addr_v6: Ipv6Addr,
     port: u16,
+    opts: SockOpt,
 ) -> io::Result<(UdpSocket, UdpSocket)> {
-    let udp_v4 = UdpSocket::bind((addr_v4, port).into())?;
+    let udp_v4 = UdpSocket::bind((addr_v4, port).into(), opts)?;
     match port {
-        0 => bind_v6_with_retry(addr_v4, addr_v6, udp_v4),
+        0 => bind_v6_with_retry(addr_v4, addr_v6, udp_v4, opts),
         p => {
-            let udp_v6 = UdpSocket::bind((addr_v6, p).into())?;
+            let udp_v6 = UdpSocket::bind((addr_v6, p).into(), opts)?;
             Ok((udp_v4, udp_v6))
         }
     }
@@ -142,18 +170,19 @@ fn bind_v6_with_retry(
     addr_v4: Ipv4Addr,
     addr_v6: Ipv6Addr,
     mut udp_v4: UdpSocket,
+    opts: SockOpt,
 ) -> io::Result<(UdpSocket, UdpSocket)> {
     let mut port = UdpSocket::local_addr(&udp_v4)?.port();
     let mut retries = 0u32;
     let udp_v6 = loop {
-        match UdpSocket::bind((addr_v6, port).into()) {
+        match UdpSocket::bind((addr_v6, port).into(), opts) {
             Ok(sock) => break sock,
             Err(err) if is_bind_retry_error(&err) && retries < BIND_MAX_RETRIES => {
                 retries += 1;
                 log::debug!(
                     "IPv6 port {port} already in use, retrying ({retries}/{BIND_MAX_RETRIES})"
                 );
-                udp_v4 = UdpSocket::bind((addr_v4, 0).into())?;
+                udp_v4 = UdpSocket::bind((addr_v4, 0).into(), opts)?;
                 port = UdpSocket::local_addr(&udp_v4)?.port();
             }
             Err(err) => return Err(err),
@@ -212,14 +241,21 @@ mod tests {
             .port();
 
         // Pre-bind IPv4 to the blocked port (succeeds because the blocker is IPv6-only).
-        let udp_v4 =
-            UdpSocket::bind((Ipv4Addr::UNSPECIFIED, blocked_port).into()).expect("bind v4");
+        let udp_v4 = UdpSocket::bind(
+            (Ipv4Addr::UNSPECIFIED, blocked_port).into(),
+            SockOpt::default(),
+        )
+        .expect("bind v4");
 
         // This should fail to bind IPv6 to blocked_port,
         // then rebind both sockets to a new random port.
-        let (udp_v4, udp_v6) =
-            bind_v6_with_retry(Ipv4Addr::UNSPECIFIED, Ipv6Addr::UNSPECIFIED, udp_v4)
-                .expect("bind_v6_with_retry");
+        let (udp_v4, udp_v6) = bind_v6_with_retry(
+            Ipv4Addr::UNSPECIFIED,
+            Ipv6Addr::UNSPECIFIED,
+            udp_v4,
+            SockOpt::default(),
+        )
+        .expect("bind_v6_with_retry");
 
         let v4_port = udp_v4.local_addr().unwrap().port();
         let v6_port = udp_v6.local_addr().unwrap().port();


### PR DESCRIPTION
Same as https://github.com/mullvad/gotatun/pull/134, but backporting to a branch based on the `0.6.0` release rather than `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/135)
<!-- Reviewable:end -->
