### PR TITLE
Use saturating addition for MTU modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Guard against `MtuWatcher` panicking on extreme MTU values.
 
 
 ## [0.7.0] - 2026-05-22

--- a/gotatun/src/tun/mod.rs
+++ b/gotatun/src/tun/mod.rs
@@ -64,7 +64,7 @@ pub trait IpRecv: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct MtuWatcher {
     mtu_source: MtuSource,
-    modifier: i32,
+    modifier: i16,
 }
 
 #[derive(Clone)]
@@ -88,11 +88,7 @@ impl MtuWatcher {
             MtuSource::Constant(mtu) => *mtu,
             MtuSource::Watch(mtu_rx) => *mtu_rx.borrow_and_update(),
         };
-
-        i32::from(mtu)
-            .checked_add(self.modifier)
-            .and_then(|int| u16::try_from(int).ok())
-            .expect("MTU over/underflow")
+        mtu.saturating_add_signed(self.modifier)
     }
 
     /// Wait for the MTU to change and return the new value.
@@ -114,7 +110,7 @@ impl MtuWatcher {
     /// Any downstream (cloned) [Self] will inherit this change, but any upstream [Self] won't.
     pub fn increase(self, value: u16) -> Option<Self> {
         Some(Self {
-            modifier: self.modifier.checked_add(i32::from(value))?,
+            modifier: self.modifier.checked_add(i16::try_from(value).ok()?)?,
             ..self
         })
     }
@@ -124,7 +120,7 @@ impl MtuWatcher {
     /// Any downstream (cloned) [Self] will inherit this change, but any upstream [Self] won't.
     pub fn decrease(self, value: u16) -> Option<Self> {
         Some(Self {
-            modifier: self.modifier.checked_sub(i32::from(value))?,
+            modifier: self.modifier.checked_sub(i16::try_from(value).ok()?)?,
             ..self
         })
     }


### PR DESCRIPTION
`MtuWatcher::get` can panic if the sum of the tunnel MTU and modifier overflows. E.g. if the actual tunnel device MTU is `65535`, a modifier of `1` will cause it to panic. The PR proposes to fix this by using saturating addition.

Those MTU values typically don't make much sense despite being technically possible, but panicking does not seem like the appropriate response here because we cannot prevent other software from changing the MTU to trigger panics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/137)
<!-- Reviewable:end -->
