### PR TITLE
Reexport tun crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Re-export `tun` crate.
+
 ### Fixed
 - Guard against `MtuWatcher` panicking on extreme MTU values.
 

--- a/gotatun/src/tun/mod.rs
+++ b/gotatun/src/tun/mod.rs
@@ -26,6 +26,10 @@ pub mod channel;
 #[cfg(feature = "pcap")]
 pub mod pcap;
 
+/// Re-export [`tun`] crate.
+#[cfg(feature = "tun")]
+pub use tun;
+
 #[cfg(feature = "tun")]
 pub mod tun_async_device;
 


### PR DESCRIPTION
Makes it more convenient to keep `tun` synced across our projects.

I'm not sure where to put this. Top level conflicts with our own `tun` module so I just put it in `tun_async_device`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/138)
<!-- Reviewable:end -->
