### PR TITLE
Reconfigure WireGuard device after calling `DeviceWrite::clear_peers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Guard against `MtuWatcher` panicking on extreme MTU values.
+- Reconfigure WireGuard device after calling `DeviceWrite::clear_peers`.
 
 
 ## [0.7.0] - 2026-05-22

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -207,6 +207,7 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
 
     /// Remove all peers, returning the number of peers removed.
     pub fn clear_peers(&mut self) -> usize {
+        self.reconfigure = Reconfigure::Yes;
         self.device.clear_peers()
     }
 


### PR DESCRIPTION
In the Mullvad VPN app, we observed problems connecting to a peer post-PSK/DAITA machine exchange with an ephemeral peer. The workaround was to completely tear down the old device and re-create an identical new device. This PR simply re configures the WireGuard device when all peer are cleared, flushing all existing connections in the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/139)
<!-- Reviewable:end -->
