### PR TITLE
Reject non-contributory Diffie-Hellman results in handshake (all-zero shared secret)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `noise::TimerParams` for tuning WireGuard timers. This is useful for obfuscation, but note
   that tweaking timers will cause the tunnel to deviate from the WireGuard spec.
+- Add `PeerPublicKey`, a peer static public key validated as contributory (not a
+  low-order Curve25519 point), and the `InvalidPeerKey` error returned when
+  validation fails. Construct one with `PeerPublicKey::new`, or
+  `PeerPublicKey::from_secret` for a key derived from a secret you hold.
 
 ### Changed
 - Enlarge the anti-replay sliding window from 1024 to 8192 packets, matching the
@@ -16,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   legitimate packets. Costs ~7 KiB more memory per peer.
 - Remove the redundant `static_public` parameter from `Tunn::set_static_private`;
   it is now derived from the private key. This is a breaking change.
+- `Tunn::new`, `Tunn::new_with_rng` and `Peer::new` now take a `PeerPublicKey`
+  instead of an `x25519::PublicKey`, rejecting low-order (non-contributory) peer
+  keys up front. This is a breaking change.
 
 ### Fixed
 - Add missing jitter for handshakes initiated due to not receiving any packets.
@@ -33,9 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce the `Reject-After-Messages` limit on the transport data counter, so a
   session is retired before its AEAD nonce can wrap and repeat.
 - Abort the handshake on a non-contributory (low-order / all-zero) Curve25519
-  Diffie-Hellman result, matching the Linux kernel and wireguard-go. A peer
-  configured with a low-order public key is accepted but can no longer complete
-  a handshake. This adds `WireGuardError::InvalidSharedSecret` which is a breaking change.
+  Diffie-Hellman result, matching the Linux kernel and wireguard-go. This guards
+  the receive path, where the peer ephemeral key arrives from the wire. This adds
+  `WireGuardError::InvalidSharedSecret` which is a breaking change. Low-order peer
+  *static* keys are instead rejected when configuring a peer (see Changed).
 
 #### Linux
 - Fix a remotely triggerable denial of service in the `recvmmsg` receive path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enlarge the anti-replay sliding window from 1024 to 8192 packets, matching the
   Linux kernel and wireguard-go. Tolerates more packet reordering before dropping
   legitimate packets. Costs ~7 KiB more memory per peer.
+- Remove the redundant `static_public` parameter from `Tunn::set_static_private`;
+  it is now derived from the private key. This is a breaking change.
 
 ### Fixed
 - Add missing jitter for handshakes initiated due to not receiving any packets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Enforce the `Reject-After-Messages` limit on the transport data counter, so a
   session is retired before its AEAD nonce can wrap and repeat.
+- Abort the handshake on a non-contributory (low-order / all-zero) Curve25519
+  Diffie-Hellman result, matching the Linux kernel and wireguard-go. A peer
+  configured with a low-order public key is accepted but can no longer complete
+  a handshake. This adds `WireGuardError::InvalidSharedSecret` which is a breaking change.
 
 #### Linux
 - Fix a remotely triggerable denial of service in the `recvmmsg` receive path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "aead",
  "aws-lc-rs",

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gotatun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.7.1"
+version = "0.8.0"
 authors.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -154,7 +154,7 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
     /// Return all peers on the device
     pub async fn peers(&self) -> Vec<PeerStats> {
         let mut peers = vec![];
-        for (pubkey, peer) in self.device.peers.iter() {
+        for (pubkey, peer) in &self.device.peers {
             let p = peer.lock().await;
 
             #[cfg(feature = "daita")]
@@ -270,7 +270,7 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
     /// All fields of the peer will be overwritten. Returns `false` if no peer with this public key
     /// exists. See also [`Self::add_or_update_peer`] and [`Self::modify_peer`].
     pub async fn update_peer(&mut self, peer: Peer) -> bool {
-        self.modify_peer(&peer.public_key, |peer_mut| {
+        self.modify_peer(peer.public_key.as_public_key(), |peer_mut| {
             peer_mut.clear_allowed_ips();
             peer_mut.add_allowed_ips(peer.allowed_ips);
             peer_mut.set_endpoint(peer.endpoint);

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -438,11 +438,10 @@ impl<T: DeviceTransports> DeviceState<T> {
         let rate_limiter = Arc::new(RateLimiter::new(&public_key, HANDSHAKE_RATE_LIMIT));
 
         for peer in self.peers.values_mut() {
-            peer.lock().await.tunnel.set_static_private(
-                private_key.clone(),
-                public_key,
-                Arc::clone(&rate_limiter),
-            )
+            peer.lock()
+                .await
+                .tunnel
+                .set_static_private(private_key.clone(), Arc::clone(&rate_limiter))
         }
 
         self.key_pair = Some((private_key, public_key));

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -38,6 +38,7 @@ use tokio::join;
 use tokio::sync::RwLock;
 use tokio::sync::{Mutex, watch};
 
+use crate::key::PeerPublicKey;
 use crate::noise::dh;
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
@@ -118,7 +119,7 @@ pub(crate) struct DeviceState<T: DeviceTransports> {
     /// MTU watcher of the TUN device.
     tun_rx_mtu: MtuWatcher,
 
-    peers: HashMap<x25519::PublicKey, Arc<Mutex<PeerState>>>,
+    peers: HashMap<PeerPublicKey, Arc<Mutex<PeerState>>>,
     peers_by_ip: AllowedIps<Arc<Mutex<PeerState>>>,
     peers_by_idx: parking_lot::Mutex<HashMap<u32, Arc<Mutex<PeerState>>>>,
     index_table: IndexTable,

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -38,6 +38,7 @@ use tokio::join;
 use tokio::sync::RwLock;
 use tokio::sync::{Mutex, watch};
 
+use crate::noise::dh;
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
@@ -568,7 +569,12 @@ impl<T: DeviceTransports> DeviceState<T> {
             let (private_key, public_key) = device.key_pair.clone().expect("Key not set");
             let rate_limiter = device.rate_limiter.clone().unwrap();
             let tun_mtu = device.tun_rx_mtu.clone();
-            (private_key, public_key, rate_limiter, tun_mtu)
+            (
+                dh::StaticSecret::from(private_key),
+                public_key,
+                rate_limiter,
+                tun_mtu,
+            )
         };
 
         while let Ok((src_buf, addr)) = udp_rx.recv_from(&mut packet_pool).await {

--- a/gotatun/src/device/peer.rs
+++ b/gotatun/src/device/peer.rs
@@ -52,6 +52,9 @@ impl Peer {
     /// Create a new peer with the given public key.
     ///
     /// All other fields are set to their default values.
+    ///
+    /// Note: a low-order (non-contributory) Curve25519 public key is accepted
+    /// here without error, but every handshake with the peer will then fail.
     pub const fn new(public_key: PublicKey) -> Self {
         Self {
             public_key,

--- a/gotatun/src/device/peer.rs
+++ b/gotatun/src/device/peer.rs
@@ -12,10 +12,10 @@
 use std::net::SocketAddr;
 
 use ipnetwork::IpNetwork;
-use x25519_dalek::PublicKey;
 
 #[cfg(feature = "daita")]
 use crate::device::daita::DaitaSettings;
+use crate::key::PeerPublicKey;
 use crate::noise::TimerParams;
 
 /// Peer data. Used to construct and update peers in a [`Device`](crate::device::Device).
@@ -23,7 +23,7 @@ use crate::noise::TimerParams;
 #[non_exhaustive]
 pub struct Peer {
     /// The peer's public key.
-    pub public_key: PublicKey,
+    pub public_key: PeerPublicKey,
     /// The peer's endpoint address (IP and port).
     ///
     /// An incoming handshake from the peer will overwrite the endpoint to the source
@@ -52,10 +52,7 @@ impl Peer {
     /// Create a new peer with the given public key.
     ///
     /// All other fields are set to their default values.
-    ///
-    /// Note: a low-order (non-contributory) Curve25519 public key is accepted
-    /// here without error, but every handshake with the peer will then fail.
-    pub const fn new(public_key: PublicKey) -> Self {
+    pub const fn new(public_key: PeerPublicKey) -> Self {
         Self {
             public_key,
             endpoint: None,

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -192,19 +192,19 @@ async fn test_endpoint_roaming() {
 #[test_log::test]
 async fn reverse_path_rejects_source_owned_by_another_peer() {
     use crate::device::Peer;
+    use crate::key::PeerPublicKey;
     use ipnetwork::Ipv4Network;
     use std::net::Ipv4Addr;
-    use x25519_dalek::{PublicKey, StaticSecret};
+    use x25519_dalek::StaticSecret;
 
     // Alice has 0.0.0.0/0 as it's allowed IP range
     let (alice, mut bob, _eve) = mock::device_pair().await;
 
     // Set up a third peer "Carol" with 10.0.0.5/32 on Bob's device
-    let carol_pub = PublicKey::from(&StaticSecret::random());
     let added = bob
         .device
         .add_peer(
-            Peer::new(carol_pub).with_allowed_ip(
+            Peer::new(PeerPublicKey::from_secret(&StaticSecret::random())).with_allowed_ip(
                 Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 5), 32)
                     .unwrap()
                     .into(),
@@ -240,7 +240,7 @@ async fn modify_peer_preshared_key_reaches_tunnel() {
         let peer = get_first_and_only_peer(device).await;
         let updated = device
             .device
-            .modify_peer(&peer.public_key, |peer_mut| {
+            .modify_peer(peer.public_key.as_public_key(), |peer_mut| {
                 peer_mut.set_preshared_key(Some(preshared_key));
             })
             .await

--- a/gotatun/src/device/tests/mock.rs
+++ b/gotatun/src/device/tests/mock.rs
@@ -25,8 +25,10 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
 };
 use tokio_stream::wrappers::BroadcastStream;
-use x25519_dalek::{PublicKey, StaticSecret};
+use x25519_dalek::StaticSecret;
 use zerocopy::IntoBytes;
+
+use crate::key::PeerPublicKey;
 
 use crate::{
     device::{Device, DeviceBuilder, Peer},
@@ -127,14 +129,11 @@ pub async fn device_pair() -> (MockDevice, MockDevice, MockEavesdropper) {
     let privkey_a = StaticSecret::random();
     let privkey_b = StaticSecret::random();
 
-    let pubkey_a = PublicKey::from(&privkey_a);
-    let pubkey_b = PublicKey::from(&privkey_b);
-
-    let peer_a = Peer::new(pubkey_a)
+    let peer_a = Peer::new(PeerPublicKey::from_secret(&privkey_a))
         .with_endpoint((endpoint_a, port).into())
         .with_allowed_ip(Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap().into());
 
-    let peer_b = Peer::new(pubkey_b)
+    let peer_b = Peer::new(PeerPublicKey::from_secret(&privkey_b))
         .with_endpoint((endpoint_b, port).into())
         .with_allowed_ip(Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap().into());
 

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -39,6 +39,7 @@ use super::{Connection, DeviceState, Reconfigure};
 use crate::device::DeviceTransports;
 #[cfg(feature = "daita-uapi")]
 use crate::device::uapi::command::SetUnset;
+use crate::key::PeerPublicKey;
 use crate::serialization::KeyBytes;
 use command::{Get, GetPeer, GetResponse, Peer, Request, Response, Set, SetPeer, SetResponse};
 use eyre::{Context, bail, eyre};
@@ -499,7 +500,7 @@ async fn on_api_get(_: Get, d: &DeviceState<impl DeviceTransports>) -> GetRespon
 
         peers.push(GetPeer {
             peer: Peer {
-                public_key: KeyBytes(*public_key.as_bytes()),
+                public_key: KeyBytes(*public_key.as_public_key().as_bytes()),
                 preshared_key: peer
                     .preshared_key()
                     .map(|key| command::SetUnset::Set(KeyBytes(key))),
@@ -632,17 +633,27 @@ async fn on_api_set(
             continue;
         }
 
+        // Reject low-order (non-contributory) peer keys up front; a handshake
+        // with such a peer could never succeed.
+        let peer_public_key = match PeerPublicKey::new(public_key) {
+            Ok(key) => key,
+            Err(error) => {
+                log::debug!("Rejecting peer: {error}");
+                return (SetResponse { errno: EINVAL }, reconfigure);
+            }
+        };
+
         let mut new_peer = match device.remove_peer(&public_key).await {
             None => {
                 // New peer
-                crate::device::Peer::new(public_key)
+                crate::device::Peer::new(peer_public_key)
             }
             Some(old_peer) => {
                 // Take existing peer
                 let peer = old_peer.lock().await;
 
                 crate::device::Peer {
-                    public_key,
+                    public_key: peer_public_key,
                     preshared_key: peer.preshared_key(),
                     endpoint: peer.endpoint().addr,
                     keepalive: peer.persistent_keepalive(),

--- a/gotatun/src/key.rs
+++ b/gotatun/src/key.rs
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! WireGuard peer keys validated at the type level.
+
+use std::borrow::Borrow;
+
+use crate::x25519;
+
+/// A peer's static public x25519 key, validated as *contributory*.
+///
+/// A low-order Curve25519 point produces an all-zero (non-contributory)
+/// Diffie-Hellman result for every scalar, making the derived key predictable to
+/// an eavesdropper. We reject these points as a hardening measure.
+///
+/// Every constructor ([`PeerPublicKey::new`] and the equivalent
+/// [`TryFrom`] impl) rejects such points, so holding a `PeerPublicKey` is proof
+/// the key passed this check. This lets the handshake code treat the peer static
+/// key as infallible rather than re-checking it on every handshake.
+///
+/// # Examples
+///
+/// ```
+/// use gotatun::{InvalidPeerKey, PeerPublicKey};
+/// use gotatun::x25519;
+///
+/// let secret = x25519::StaticSecret::from([0x42; 32]);
+/// let public_key = x25519::PublicKey::from(&secret);
+/// let peer_public_key = PeerPublicKey::new(public_key)?;
+/// # Ok::<(), InvalidPeerKey>(())
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PeerPublicKey(x25519::PublicKey);
+
+impl PeerPublicKey {
+    /// Validates `public_key` as contributory and wraps it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPeerKey`] if `public_key` is a low-order
+    /// (non-contributory) Curve25519 point.
+    pub fn new(public_key: x25519::PublicKey) -> Result<Self, InvalidPeerKey> {
+        // An arbitrary fixed private key (a scalar). X25519 multiplies it by
+        // the public key (a curve point); whether the product is all-zero
+        // (non-contributory) depends only on the public key, so one fixed
+        // non-low-order private key reveals every low-order public key. This
+        // is a complete check: it also rejects low-order keys on the curve's
+        // twist, not just the canonical curve points.
+        const PROBE_SCALAR: [u8; 32] = [1u8; 32];
+
+        let probe = x25519::StaticSecret::from(PROBE_SCALAR);
+        if probe.diffie_hellman(&public_key).was_contributory() {
+            Ok(Self(public_key))
+        } else {
+            Err(InvalidPeerKey)
+        }
+    }
+
+    /// The public key for `secret`, wrapped as a `PeerPublicKey`.
+    ///
+    /// A public key derived from a secret key is the basepoint times a clamped
+    /// scalar, which always lands in the prime-order subgroup and so is never
+    /// low-order. Unlike [`PeerPublicKey::new`] this therefore needs no
+    /// validation and cannot fail.
+    pub fn from_secret(secret: &x25519::StaticSecret) -> Self {
+        Self(x25519::PublicKey::from(secret))
+    }
+
+    /// The wrapped [`x25519::PublicKey`].
+    pub fn as_public_key(&self) -> &x25519::PublicKey {
+        &self.0
+    }
+}
+
+impl From<PeerPublicKey> for x25519::PublicKey {
+    fn from(peer_public_key: PeerPublicKey) -> Self {
+        peer_public_key.0
+    }
+}
+
+// A `PeerPublicKey` hashes and compares identically to its inner
+// `x25519::PublicKey` (the derived `Hash`/`Eq` just delegate to the single
+// field), so it can be used as a map key while still being looked up by a plain
+// `x25519::PublicKey`, e.g. one reconstructed from a received handshake.
+impl Borrow<x25519::PublicKey> for PeerPublicKey {
+    fn borrow(&self) -> &x25519::PublicKey {
+        &self.0
+    }
+}
+
+impl TryFrom<x25519::PublicKey> for PeerPublicKey {
+    type Error = InvalidPeerKey;
+
+    /// Equivalent to [`PeerPublicKey::new`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPeerKey`] if `public_key` is a low-order
+    /// (non-contributory) Curve25519 point.
+    fn try_from(public_key: x25519::PublicKey) -> Result<Self, InvalidPeerKey> {
+        Self::new(public_key)
+    }
+}
+
+/// A peer public key was a low-order (non-contributory) Curve25519 point.
+///
+/// See [`PeerPublicKey`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+#[error("peer public key is a low-order (non-contributory) Curve25519 point")]
+pub struct InvalidPeerKey;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::noise::handshake::low_order_keys;
+
+    /// A genuine, randomly generated public key is accepted.
+    #[test]
+    fn accepts_contributory_key() {
+        let public_key =
+            x25519::PublicKey::from(&x25519::StaticSecret::random_from_rng(rand_core::OsRng));
+        assert!(PeerPublicKey::new(public_key).is_ok());
+    }
+
+    /// Every known low-order point is rejected at construction.
+    #[test]
+    fn rejects_low_order_keys() {
+        for low_order in low_order_keys() {
+            let public_key = x25519::PublicKey::from(low_order);
+            assert_eq!(
+                PeerPublicKey::new(public_key),
+                Err(InvalidPeerKey),
+                "point {low_order:02x?}: expected rejection"
+            );
+        }
+    }
+
+    /// Deriving from a secret yields the same key as validating it.
+    #[test]
+    fn from_secret_matches_validation() {
+        let secret = x25519::StaticSecret::random_from_rng(rand_core::OsRng);
+        let public_key = x25519::PublicKey::from(&secret);
+        assert_eq!(
+            PeerPublicKey::from_secret(&secret),
+            PeerPublicKey::new(public_key).unwrap()
+        );
+    }
+}

--- a/gotatun/src/lib.rs
+++ b/gotatun/src/lib.rs
@@ -22,10 +22,13 @@
 mod crypto;
 #[cfg(feature = "device")]
 pub mod device;
+mod key;
 pub mod noise;
 pub mod packet;
 pub mod tun;
 pub mod udp;
+
+pub use key::{InvalidPeerKey, PeerPublicKey};
 
 mod task;
 

--- a/gotatun/src/noise/dh.rs
+++ b/gotatun/src/noise/dh.rs
@@ -9,18 +9,21 @@
 //! X25519 key agreement wrappers that make it impossible to accidentally use a
 //! non-contributory (all-zero) Diffie-Hellman result.
 //!
-//! The contributory check is the only way to construct a [`SharedSecret`], and
-//! a [`SharedSecret`] is the only thing in this module that exposes secret
-//! bytes. Because the wrapped `x25519_dalek` types are private to this module,
-//! code outside it cannot reach dalek's unchecked `diffie_hellman` nor read a
-//! raw shared secret. The check is therefore not merely easy to remember, it is
-//! impossible to bypass.
+//! A [`SharedSecret`] can only be obtained either by passing the runtime
+//! contributory check (the fallible `dh` methods) or by agreeing against a
+//! validated [`PeerPublicKey`] (the infallible `dh_validated` methods), which
+//! guarantees the same property at the type level. A [`SharedSecret`] is the
+//! only thing in this module that exposes secret bytes, and because the wrapped
+//! `x25519_dalek` types are private to the module, code outside it cannot reach
+//! dalek's unchecked `diffie_hellman` nor read a raw shared secret. The check is
+//! therefore not merely easy to remember, it is impossible to bypass.
 //!
 //! A non-contributory result is produced by a low-order peer public key. The
 //! Noise spec treats rejecting it as optional (§12.1), but the Linux kernel
 //! WireGuard implementation does so as a fail-fast hardening measure
 //! (`mix_dh`/`curve25519`); this matches its behavior.
 
+use crate::key::PeerPublicKey;
 use crate::noise::errors::WireGuardError;
 use crate::x25519;
 
@@ -42,6 +45,16 @@ impl StaticSecret {
     /// non-contributory (all-zero), indicating a low-order `peer` key.
     pub(crate) fn dh(&self, peer: &x25519::PublicKey) -> Result<SharedSecret, WireGuardError> {
         SharedSecret::checked(self.0.diffie_hellman(peer))
+    }
+
+    /// Performs the key agreement against a validated `peer` key.
+    ///
+    /// Unlike [`StaticSecret::dh`] this is infallible. Whether a result is
+    /// non-contributory depends only on the public key, not the scalar, and a
+    /// [`PeerPublicKey`] is guaranteed not to be low-order, so the result is
+    /// always contributory.
+    pub(crate) fn dh_validated(&self, peer: &PeerPublicKey) -> SharedSecret {
+        SharedSecret(self.0.diffie_hellman(peer.as_public_key()))
     }
 }
 
@@ -77,14 +90,26 @@ impl EphemeralSecret {
     pub(crate) fn dh(&self, peer: &x25519::PublicKey) -> Result<SharedSecret, WireGuardError> {
         SharedSecret::checked(self.0.diffie_hellman(peer))
     }
+
+    /// Performs the key agreement against a validated `peer` key.
+    ///
+    /// Unlike [`EphemeralSecret::dh`] this is infallible. Whether a result is
+    /// non-contributory depends only on the public key, not the scalar, and a
+    /// [`PeerPublicKey`] is guaranteed not to be low-order, so the result is
+    /// always contributory.
+    pub(crate) fn dh_validated(&self, peer: &PeerPublicKey) -> SharedSecret {
+        SharedSecret(self.0.diffie_hellman(peer.as_public_key()))
+    }
 }
 
-/// A shared secret that has passed the non-contributory check.
+/// A contributory shared secret.
 ///
-/// The only constructor is the private [`SharedSecret::checked`], reachable
-/// solely through [`StaticSecret::dh`] / [`EphemeralSecret::dh`], so merely
-/// holding a value of this type is proof the check passed. Its bytes leave the
-/// module only as the `&[u8; 32]` returned by [`SharedSecret::as_bytes`].
+/// Every `SharedSecret` is contributory, established either by the runtime check
+/// in the private [`SharedSecret::checked`] (used by the fallible `dh` methods)
+/// or by agreeing against a validated [`PeerPublicKey`] via the `dh_validated`
+/// methods. Holding a value of this type is therefore proof of contributoriness.
+/// Its bytes leave the module only as the `&[u8; 32]` returned by
+/// [`SharedSecret::as_bytes`].
 pub(crate) struct SharedSecret(x25519::SharedSecret);
 
 impl SharedSecret {

--- a/gotatun/src/noise/dh.rs
+++ b/gotatun/src/noise/dh.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! X25519 key agreement wrappers that make it impossible to accidentally use a
+//! non-contributory (all-zero) Diffie-Hellman result.
+//!
+//! The contributory check is the only way to construct a [`SharedSecret`], and
+//! a [`SharedSecret`] is the only thing in this module that exposes secret
+//! bytes. Because the wrapped `x25519_dalek` types are private to this module,
+//! code outside it cannot reach dalek's unchecked `diffie_hellman` nor read a
+//! raw shared secret. The check is therefore not merely easy to remember, it is
+//! impossible to bypass.
+//!
+//! A non-contributory result is produced by a low-order peer public key. The
+//! Noise spec treats rejecting it as optional (§12.1), but the Linux kernel
+//! WireGuard implementation does so as a fail-fast hardening measure
+//! (`mix_dh`/`curve25519`); this matches its behavior.
+
+use crate::noise::errors::WireGuardError;
+use crate::x25519;
+
+/// A long-term static secret key. Wraps the dalek key so the only key agreement
+/// it offers is the checked [`StaticSecret::dh`].
+pub(crate) struct StaticSecret(x25519::StaticSecret);
+
+impl StaticSecret {
+    /// The public key corresponding to this secret key.
+    pub(crate) fn public_key(&self) -> x25519::PublicKey {
+        x25519::PublicKey::from(&self.0)
+    }
+
+    /// Performs the key agreement against `peer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WireGuardError::InvalidSharedSecret`] if the result is
+    /// non-contributory (all-zero), indicating a low-order `peer` key.
+    pub(crate) fn dh(&self, peer: &x25519::PublicKey) -> Result<SharedSecret, WireGuardError> {
+        SharedSecret::checked(self.0.diffie_hellman(peer))
+    }
+}
+
+impl From<x25519::StaticSecret> for StaticSecret {
+    fn from(secret: x25519::StaticSecret) -> Self {
+        Self(secret)
+    }
+}
+
+/// A per-handshake ephemeral secret key. Wraps `ReusableSecret` rather than
+/// dalek's `EphemeralSecret`, because the latter is consumed by value on a
+/// single agreement, while a handshake performs two agreements with the same
+/// ephemeral key.
+pub(crate) struct EphemeralSecret(x25519::ReusableSecret);
+
+impl EphemeralSecret {
+    /// Generates a fresh ephemeral secret key.
+    pub(crate) fn random() -> Self {
+        Self(x25519::ReusableSecret::random_from_rng(rand_core::OsRng))
+    }
+
+    /// The public key corresponding to this secret key.
+    pub(crate) fn public_key(&self) -> x25519::PublicKey {
+        x25519::PublicKey::from(&self.0)
+    }
+
+    /// Performs the key agreement against `peer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WireGuardError::InvalidSharedSecret`] if the result is
+    /// non-contributory (all-zero), indicating a low-order `peer` key.
+    pub(crate) fn dh(&self, peer: &x25519::PublicKey) -> Result<SharedSecret, WireGuardError> {
+        SharedSecret::checked(self.0.diffie_hellman(peer))
+    }
+}
+
+/// A shared secret that has passed the non-contributory check.
+///
+/// The only constructor is the private [`SharedSecret::checked`], reachable
+/// solely through [`StaticSecret::dh`] / [`EphemeralSecret::dh`], so merely
+/// holding a value of this type is proof the check passed. Its bytes leave the
+/// module only as the `&[u8; 32]` returned by [`SharedSecret::as_bytes`].
+pub(crate) struct SharedSecret(x25519::SharedSecret);
+
+impl SharedSecret {
+    /// Wraps a raw shared secret, rejecting a non-contributory (all-zero) one.
+    fn checked(shared: x25519::SharedSecret) -> Result<Self, WireGuardError> {
+        if shared.was_contributory() {
+            Ok(Self(shared))
+        } else {
+            Err(WireGuardError::InvalidSharedSecret)
+        }
+    }
+
+    /// The shared secret bytes, safe to mix into the KDF.
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}

--- a/gotatun/src/noise/errors.rs
+++ b/gotatun/src/noise/errors.rs
@@ -45,4 +45,8 @@ pub enum WireGuardError {
     LockFailed,
     /// The connection has expired and is no longer valid.
     ConnectionExpired,
+    /// A Diffie-Hellman operation produced a non-contributory (all-zero)
+    /// shared secret, indicating a low-order peer public key. The handshake
+    /// is aborted.
+    InvalidSharedSecret,
 }

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -355,12 +355,12 @@ pub struct HalfHandshake {
 /// # Errors
 ///
 /// Returns an error if the packet is malformed or cryptographic validation fails.
-pub fn parse_handshake_anon(
-    static_private: &x25519::StaticSecret,
+#[cfg(any(feature = "device", test))]
+pub(crate) fn parse_handshake_anon(
+    static_private: &dh::StaticSecret,
     static_public: &x25519::PublicKey,
     packet: &WgHandshakeInit,
 ) -> Result<HalfHandshake, WireGuardError> {
-    let static_private = dh::StaticSecret::from(static_private.clone());
     let peer_index = packet.sender_idx.get();
     // initiator.chaining_key = HASH(CONSTRUCTION)
     let mut chaining_key = INITIAL_CHAIN_KEY;
@@ -1057,8 +1057,9 @@ mod tests {
     // corresponding sending direction (an initiator refusing to emit an initiation).
     #[test]
     fn rejects_low_order_ephemeral_in_initiation() {
-        let responder_private = x25519::StaticSecret::random_from_rng(rand_core::OsRng);
-        let responder_public = x25519::PublicKey::from(&responder_private);
+        let responder_private =
+            dh::StaticSecret::from(x25519::StaticSecret::random_from_rng(rand_core::OsRng));
+        let responder_public = responder_private.public_key();
 
         for low_order in low_order_keys() {
             let packet =

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -426,17 +426,9 @@ impl NoiseParams {
     }
 
     /// Set a new private key
-    fn set_static_private(
-        &mut self,
-        static_private: dh::StaticSecret,
-        static_public: x25519::PublicKey,
-    ) {
-        // Check that the public key indeed matches the private key
-        let check_key = static_private.public_key();
-        assert_eq!(check_key.as_bytes(), static_public.as_bytes());
-
+    fn set_static_private(&mut self, static_private: dh::StaticSecret) {
+        self.static_public = static_private.public_key();
         self.static_private = static_private;
-        self.static_public = static_public;
 
         self.static_shared = self.static_private.dh(&self.peer_static_public).ok();
     }
@@ -503,12 +495,8 @@ impl Handshake {
         self.cookies.write_cookie = None;
     }
 
-    pub(crate) fn set_static_private(
-        &mut self,
-        private_key: dh::StaticSecret,
-        public_key: x25519::PublicKey,
-    ) {
-        self.params.set_static_private(private_key, public_key);
+    pub(crate) fn set_static_private(&mut self, private_key: dh::StaticSecret) {
+        self.params.set_static_private(private_key);
         // Invalidate in-flight handshakes
         self.state = HandshakeState::None;
         self.previous = HandshakeState::None;

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::crypto::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
+use crate::noise::dh;
 use crate::noise::errors::WireGuardError;
 use crate::noise::index_table::{Index, IndexTable};
 use crate::noise::session::Session;
@@ -244,11 +245,13 @@ struct NoiseParams {
     /// Our static public key
     static_public: x25519::PublicKey,
     /// Our static private key
-    static_private: x25519::StaticSecret,
+    static_private: dh::StaticSecret,
     /// Static public key of the other party
     peer_static_public: x25519::PublicKey,
-    /// A shared key = DH(`static_private`, `peer_static_public`)
-    static_shared: x25519::SharedSecret,
+    /// A shared key = DH(`static_private`, `peer_static_public`), precomputed
+    /// once per peer. `None` means the peer's static key is low-order
+    /// (non-contributory); that aborts the handshake when it tries to use it.
+    static_shared: Option<dh::SharedSecret>,
     /// A pre-computation of HASH("mac1----", `peer_static_public`) for this peer
     sending_mac1_key: [u8; KEY_LEN],
     /// An optional preshared key
@@ -272,7 +275,7 @@ struct HandshakeInitSentState {
     local_index: Index,
     hash: [u8; KEY_LEN],
     chaining_key: [u8; KEY_LEN],
-    ephemeral_private: x25519::ReusableSecret,
+    ephemeral_private: dh::EphemeralSecret,
     time_sent: Instant,
 }
 
@@ -357,6 +360,7 @@ pub fn parse_handshake_anon(
     static_public: &x25519::PublicKey,
     packet: &WgHandshakeInit,
 ) -> Result<HalfHandshake, WireGuardError> {
+    let static_private = dh::StaticSecret::from(static_private.clone());
     let peer_index = packet.sender_idx.get();
     // initiator.chaining_key = HASH(CONSTRUCTION)
     let mut chaining_key = INITIAL_CHAIN_KEY;
@@ -374,8 +378,10 @@ pub fn parse_handshake_anon(
         &[0x01],
     );
     // temp = HMAC(initiator.chaining_key, DH(initiator.ephemeral_private, responder.static_public))
-    let ephemeral_shared = static_private.diffie_hellman(&peer_ephemeral_public);
-    let temp = b2s_hmac(&chaining_key, &ephemeral_shared.to_bytes());
+    let temp = b2s_hmac(
+        &chaining_key,
+        static_private.dh(&peer_ephemeral_public)?.as_bytes(),
+    );
     // initiator.chaining_key = HMAC(temp, 0x1)
     chaining_key = b2s_hmac(&temp, &[0x01]);
     // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -400,12 +406,12 @@ pub fn parse_handshake_anon(
 impl NoiseParams {
     /// New noise params struct from our secret key, peers public key, and optional preshared key
     fn new(
-        static_private: x25519::StaticSecret,
-        static_public: x25519::PublicKey,
+        static_private: dh::StaticSecret,
         peer_static_public: x25519::PublicKey,
         preshared_key: Option<[u8; 32]>,
     ) -> NoiseParams {
-        let static_shared = static_private.diffie_hellman(&peer_static_public);
+        let static_public = static_private.public_key();
+        let static_shared = static_private.dh(&peer_static_public).ok();
 
         let initial_sending_mac_key = b2s_hash(LABEL_MAC1, peer_static_public.as_bytes());
 
@@ -422,17 +428,25 @@ impl NoiseParams {
     /// Set a new private key
     fn set_static_private(
         &mut self,
-        static_private: x25519::StaticSecret,
+        static_private: dh::StaticSecret,
         static_public: x25519::PublicKey,
     ) {
         // Check that the public key indeed matches the private key
-        let check_key = x25519::PublicKey::from(&static_private);
+        let check_key = static_private.public_key();
         assert_eq!(check_key.as_bytes(), static_public.as_bytes());
 
         self.static_private = static_private;
         self.static_public = static_public;
 
-        self.static_shared = self.static_private.diffie_hellman(&self.peer_static_public);
+        self.static_shared = self.static_private.dh(&self.peer_static_public).ok();
+    }
+
+    /// The precomputed static-static shared secret, or an error if the peer's
+    /// static key is low-order (non-contributory).
+    fn static_shared(&self) -> Result<&dh::SharedSecret, WireGuardError> {
+        self.static_shared
+            .as_ref()
+            .ok_or(WireGuardError::InvalidSharedSecret)
     }
 
     fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
@@ -442,18 +456,12 @@ impl NoiseParams {
 
 impl Handshake {
     pub(crate) fn new(
-        static_private: x25519::StaticSecret,
-        static_public: x25519::PublicKey,
+        static_private: dh::StaticSecret,
         peer_static_public: x25519::PublicKey,
         index_table: IndexTable,
         preshared_key: Option<[u8; 32]>,
     ) -> Handshake {
-        let params = NoiseParams::new(
-            static_private,
-            static_public,
-            peer_static_public,
-            preshared_key,
-        );
+        let params = NoiseParams::new(static_private, peer_static_public, preshared_key);
 
         Handshake {
             params,
@@ -497,7 +505,7 @@ impl Handshake {
 
     pub(crate) fn set_static_private(
         &mut self,
-        private_key: x25519::StaticSecret,
+        private_key: dh::StaticSecret,
         public_key: x25519::PublicKey,
     ) {
         self.params.set_static_private(private_key, public_key);
@@ -540,11 +548,13 @@ impl Handshake {
             &[0x01],
         );
         // temp = HMAC(initiator.chaining_key, DH(initiator.ephemeral_private, responder.static_public))
-        let ephemeral_shared = self
-            .params
-            .static_private
-            .diffie_hellman(&peer_ephemeral_public);
-        let temp = b2s_hmac(&chaining_key, &ephemeral_shared.to_bytes());
+        let temp = b2s_hmac(
+            &chaining_key,
+            self.params
+                .static_private
+                .dh(&peer_ephemeral_public)?
+                .as_bytes(),
+        );
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -570,7 +580,8 @@ impl Handshake {
         // initiator.hash = HASH(initiator.hash || msg.encrypted_static)
         hash = b2s_hash(&hash, packet.encrypted_static.as_bytes());
         // temp = HMAC(initiator.chaining_key, DH(initiator.static_private, responder.static_public))
-        let temp = b2s_hmac(&chaining_key, self.params.static_shared.as_bytes());
+        // Abort if the precomputed static-static is non-contributory.
+        let temp = b2s_hmac(&chaining_key, self.params.static_shared()?.as_bytes());
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -599,7 +610,7 @@ impl Handshake {
             },
         );
 
-        Ok(self.format_handshake_response(packet.into_bytes()))
+        self.format_handshake_response(packet.into_bytes())
     }
 
     pub(super) fn receive_handshake_response(
@@ -625,20 +636,22 @@ impl Handshake {
         // responder.chaining_key = HMAC(temp, 0x1)
         let mut chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, DH(responder.ephemeral_private, initiator.ephemeral_public))
-        let ephemeral_shared = state
-            .ephemeral_private
-            .diffie_hellman(&unencrypted_ephemeral);
-        let temp = b2s_hmac(&chaining_key, &ephemeral_shared.to_bytes());
+        let temp = b2s_hmac(
+            &chaining_key,
+            state
+                .ephemeral_private
+                .dh(&unencrypted_ephemeral)?
+                .as_bytes(),
+        );
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, DH(responder.ephemeral_private, initiator.static_public))
         let temp = b2s_hmac(
             &chaining_key,
-            &self
-                .params
+            self.params
                 .static_private
-                .diffie_hellman(&unencrypted_ephemeral)
-                .to_bytes(),
+                .dh(&unencrypted_ephemeral)?
+                .as_bytes(),
         );
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
@@ -752,7 +765,9 @@ impl Handshake {
         self.cookies.last_mac1 = Some(*packet.mac1());
     }
 
-    pub(super) fn format_handshake_initiation(&mut self) -> crate::packet::Packet<WgHandshakeInit> {
+    pub(super) fn format_handshake_initiation(
+        &mut self,
+    ) -> Result<crate::packet::Packet<WgHandshakeInit>, WireGuardError> {
         let mut handshake = WgHandshakeInit::new();
 
         let local_index = self.index_table.new_index();
@@ -764,7 +779,7 @@ impl Handshake {
         let mut hash = INITIAL_CHAIN_HASH;
         hash = b2s_hash(&hash, self.params.peer_static_public.as_bytes());
         // initiator.ephemeral_private = DH_GENERATE()
-        let ephemeral_private = x25519::ReusableSecret::random_from_rng(rand_core::OsRng);
+        let ephemeral_private = dh::EphemeralSecret::random();
         // msg.message_type = 1
         // msg.reserved_zero = { 0, 0, 0 }
         // msg.sender_index = little_endian(initiator.sender_index)
@@ -772,7 +787,7 @@ impl Handshake {
         // msg.unencrypted_ephemeral = DH_PUBKEY(initiator.ephemeral_private)
         handshake
             .unencrypted_ephemeral
-            .copy_from_slice(x25519::PublicKey::from(&ephemeral_private).as_bytes());
+            .copy_from_slice(ephemeral_private.public_key().as_bytes());
         // initiator.hash = HASH(initiator.hash || msg.unencrypted_ephemeral)
         hash = b2s_hash(&hash, &handshake.unencrypted_ephemeral);
         // temp = HMAC(initiator.chaining_key, msg.unencrypted_ephemeral)
@@ -782,8 +797,12 @@ impl Handshake {
             &[0x01],
         );
         // temp = HMAC(initiator.chaining_key, DH(initiator.ephemeral_private, responder.static_public))
-        let ephemeral_shared = ephemeral_private.diffie_hellman(&self.params.peer_static_public);
-        let temp = b2s_hmac(&chaining_key, &ephemeral_shared.to_bytes());
+        let temp = b2s_hmac(
+            &chaining_key,
+            ephemeral_private
+                .dh(&self.params.peer_static_public)?
+                .as_bytes(),
+        );
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -799,7 +818,8 @@ impl Handshake {
         // initiator.hash = HASH(initiator.hash || msg.encrypted_static)
         hash = b2s_hash(&hash, handshake.encrypted_static.as_bytes());
         // temp = HMAC(initiator.chaining_key, DH(initiator.static_private, responder.static_public))
-        let temp = b2s_hmac(&chaining_key, self.params.static_shared.as_bytes());
+        // Abort if the precomputed static-static is non-contributory.
+        let temp = b2s_hmac(&chaining_key, self.params.static_shared()?.as_bytes());
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -830,13 +850,13 @@ impl Handshake {
 
         self.init_mac1_and_mac2(&mut handshake, local_index_val);
 
-        Packet::copy_from(&handshake)
+        Ok(Packet::copy_from(&handshake))
     }
 
     fn format_handshake_response(
         &mut self,
         buf: crate::packet::Packet,
-    ) -> (crate::packet::Packet<WgHandshakeResp>, Session) {
+    ) -> Result<(crate::packet::Packet<WgHandshakeResp>, Session), WireGuardError> {
         let state = std::mem::replace(&mut self.state, HandshakeState::None);
         let (mut chaining_key, mut hash, peer_ephemeral_public, peer_index) = match state {
             HandshakeState::InitReceived {
@@ -851,7 +871,7 @@ impl Handshake {
         };
 
         // responder.ephemeral_private = DH_GENERATE()
-        let ephemeral_private = x25519::ReusableSecret::random_from_rng(rand_core::OsRng);
+        let ephemeral_private = dh::EphemeralSecret::random();
         let local_index = self.index_table.new_index();
         let local_index_val = local_index.value();
         // msg.message_type = 2
@@ -859,7 +879,7 @@ impl Handshake {
         let mut resp = WgHandshakeResp::new(
             local_index_val,
             peer_index,
-            *x25519::PublicKey::from(&ephemeral_private).as_bytes(),
+            *ephemeral_private.public_key().as_bytes(),
         );
         // msg.sender_index = little_endian(responder.sender_index)
         // msg.receiver_index = little_endian(initiator.sender_index)
@@ -871,16 +891,18 @@ impl Handshake {
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, DH(responder.ephemeral_private, initiator.ephemeral_public))
-        let ephemeral_shared = ephemeral_private.diffie_hellman(&peer_ephemeral_public);
-        let temp = b2s_hmac(&chaining_key, &ephemeral_shared.to_bytes());
+        let temp = b2s_hmac(
+            &chaining_key,
+            ephemeral_private.dh(&peer_ephemeral_public)?.as_bytes(),
+        );
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, DH(responder.ephemeral_private, initiator.static_public))
         let temp = b2s_hmac(
             &chaining_key,
-            &ephemeral_private
-                .diffie_hellman(&self.params.peer_static_public)
-                .to_bytes(),
+            ephemeral_private
+                .dh(&self.params.peer_static_public)?
+                .as_bytes(),
         );
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
@@ -916,7 +938,7 @@ impl Handshake {
 
         let packet = buf.overwrite_with(&resp);
 
-        (packet, Session::new(local_index, peer_index, temp2, temp3))
+        Ok((packet, Session::new(local_index, peer_index, temp2, temp3)))
     }
 }
 
@@ -1055,8 +1077,8 @@ mod tests {
                 craft_anon_initiation_with_low_order_ephemeral(&responder_public, low_order);
             let result = parse_handshake_anon(&responder_private, &responder_public, &packet);
             assert!(
-                result.is_err(),
-                "point {low_order:02x?}: handshake must be rejected, got {result:?}"
+                matches!(result, Err(WireGuardError::InvalidSharedSecret)),
+                "point {low_order:02x?}: expected InvalidSharedSecret, got {result:?}"
             );
         }
     }

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::crypto::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
+use crate::key::PeerPublicKey;
 use crate::noise::dh;
 use crate::noise::errors::WireGuardError;
 use crate::noise::index_table::{Index, IndexTable};
@@ -247,11 +248,11 @@ struct NoiseParams {
     /// Our static private key
     static_private: dh::StaticSecret,
     /// Static public key of the other party
-    peer_static_public: x25519::PublicKey,
+    peer_static_public: PeerPublicKey,
     /// A shared key = DH(`static_private`, `peer_static_public`), precomputed
-    /// once per peer. `None` means the peer's static key is low-order
-    /// (non-contributory); that aborts the handshake when it tries to use it.
-    static_shared: Option<dh::SharedSecret>,
+    /// once per peer. Always contributory, because `peer_static_public` is a
+    /// validated [`PeerPublicKey`].
+    static_shared: dh::SharedSecret,
     /// A pre-computation of HASH("mac1----", `peer_static_public`) for this peer
     sending_mac1_key: [u8; KEY_LEN],
     /// An optional preshared key
@@ -407,13 +408,14 @@ impl NoiseParams {
     /// New noise params struct from our secret key, peers public key, and optional preshared key
     fn new(
         static_private: dh::StaticSecret,
-        peer_static_public: x25519::PublicKey,
+        peer_static_public: PeerPublicKey,
         preshared_key: Option<[u8; 32]>,
     ) -> NoiseParams {
         let static_public = static_private.public_key();
-        let static_shared = static_private.dh(&peer_static_public).ok();
+        let static_shared = static_private.dh_validated(&peer_static_public);
 
-        let initial_sending_mac_key = b2s_hash(LABEL_MAC1, peer_static_public.as_bytes());
+        let initial_sending_mac_key =
+            b2s_hash(LABEL_MAC1, peer_static_public.as_public_key().as_bytes());
 
         NoiseParams {
             static_public,
@@ -428,17 +430,14 @@ impl NoiseParams {
     /// Set a new private key
     fn set_static_private(&mut self, static_private: dh::StaticSecret) {
         self.static_public = static_private.public_key();
+        self.static_shared = static_private.dh_validated(&self.peer_static_public);
         self.static_private = static_private;
-
-        self.static_shared = self.static_private.dh(&self.peer_static_public).ok();
     }
 
-    /// The precomputed static-static shared secret, or an error if the peer's
-    /// static key is low-order (non-contributory).
-    fn static_shared(&self) -> Result<&dh::SharedSecret, WireGuardError> {
-        self.static_shared
-            .as_ref()
-            .ok_or(WireGuardError::InvalidSharedSecret)
+    /// The precomputed static-static shared secret. Always contributory; see
+    /// [`NoiseParams::static_shared`](Self::static_shared) (the field).
+    fn static_shared(&self) -> &dh::SharedSecret {
+        &self.static_shared
     }
 
     fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
@@ -449,7 +448,7 @@ impl NoiseParams {
 impl Handshake {
     pub(crate) fn new(
         static_private: dh::StaticSecret,
-        peer_static_public: x25519::PublicKey,
+        peer_static_public: PeerPublicKey,
         index_table: IndexTable,
         preshared_key: Option<[u8; 32]>,
     ) -> Handshake {
@@ -559,7 +558,7 @@ impl Handshake {
         )?;
 
         if !constant_time_eq_n(
-            self.params.peer_static_public.as_bytes(),
+            self.params.peer_static_public.as_public_key().as_bytes(),
             &peer_static_public_decrypted,
         ) {
             return Err(WireGuardError::WrongKey);
@@ -568,8 +567,7 @@ impl Handshake {
         // initiator.hash = HASH(initiator.hash || msg.encrypted_static)
         hash = b2s_hash(&hash, packet.encrypted_static.as_bytes());
         // temp = HMAC(initiator.chaining_key, DH(initiator.static_private, responder.static_public))
-        // Abort if the precomputed static-static is non-contributory.
-        let temp = b2s_hmac(&chaining_key, self.params.static_shared()?.as_bytes());
+        let temp = b2s_hmac(&chaining_key, self.params.static_shared().as_bytes());
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -719,7 +717,10 @@ impl Handshake {
             return Err(WireGuardError::WrongIndex);
         }
         // msg.encrypted_cookie = XAEAD(HASH(LABEL_COOKIE || responder.static_public), msg.nonce, cookie, last_received_msg.mac1)
-        let key = b2s_hash(LABEL_COOKIE, self.params.peer_static_public.as_bytes()); // TODO: pre-compute
+        let key = b2s_hash(
+            LABEL_COOKIE,
+            self.params.peer_static_public.as_public_key().as_bytes(),
+        ); // TODO: pre-compute
 
         let payload = Payload {
             aad: &mac1,
@@ -753,9 +754,7 @@ impl Handshake {
         self.cookies.last_mac1 = Some(*packet.mac1());
     }
 
-    pub(super) fn format_handshake_initiation(
-        &mut self,
-    ) -> Result<crate::packet::Packet<WgHandshakeInit>, WireGuardError> {
+    pub(super) fn format_handshake_initiation(&mut self) -> crate::packet::Packet<WgHandshakeInit> {
         let mut handshake = WgHandshakeInit::new();
 
         let local_index = self.index_table.new_index();
@@ -765,7 +764,10 @@ impl Handshake {
         let mut chaining_key = INITIAL_CHAIN_KEY;
         // initiator.hash = HASH(HASH(initiator.chaining_key || IDENTIFIER) || responder.static_public)
         let mut hash = INITIAL_CHAIN_HASH;
-        hash = b2s_hash(&hash, self.params.peer_static_public.as_bytes());
+        hash = b2s_hash(
+            &hash,
+            self.params.peer_static_public.as_public_key().as_bytes(),
+        );
         // initiator.ephemeral_private = DH_GENERATE()
         let ephemeral_private = dh::EphemeralSecret::random();
         // msg.message_type = 1
@@ -788,7 +790,7 @@ impl Handshake {
         let temp = b2s_hmac(
             &chaining_key,
             ephemeral_private
-                .dh(&self.params.peer_static_public)?
+                .dh_validated(&self.params.peer_static_public)
                 .as_bytes(),
         );
         // initiator.chaining_key = HMAC(temp, 0x1)
@@ -806,8 +808,7 @@ impl Handshake {
         // initiator.hash = HASH(initiator.hash || msg.encrypted_static)
         hash = b2s_hash(&hash, handshake.encrypted_static.as_bytes());
         // temp = HMAC(initiator.chaining_key, DH(initiator.static_private, responder.static_public))
-        // Abort if the precomputed static-static is non-contributory.
-        let temp = b2s_hmac(&chaining_key, self.params.static_shared()?.as_bytes());
+        let temp = b2s_hmac(&chaining_key, self.params.static_shared().as_bytes());
         // initiator.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // key = HMAC(temp, initiator.chaining_key || 0x2)
@@ -838,7 +839,7 @@ impl Handshake {
 
         self.init_mac1_and_mac2(&mut handshake, local_index_val);
 
-        Ok(Packet::copy_from(&handshake))
+        Packet::copy_from(&handshake)
     }
 
     fn format_handshake_response(
@@ -889,7 +890,7 @@ impl Handshake {
         let temp = b2s_hmac(
             &chaining_key,
             ephemeral_private
-                .dh(&self.params.peer_static_public)?
+                .dh_validated(&self.params.peer_static_public)
                 .as_bytes(),
         );
         // responder.chaining_key = HMAC(temp, 0x1)
@@ -1051,10 +1052,14 @@ mod tests {
     // Tests the receiving direction: a remote initiator sends us a low-order public ephemeral key.
     //
     // Such an ephemeral yields a non-contributory (all-zero) DH; it must be
-    // rejected.
+    // rejected. The peer's ephemeral key is attacker-controlled and arrives on
+    // every handshake, so unlike the peer static key it cannot be validated up
+    // front and must be checked here at runtime.
     //
-    // See the `low_order_peer_static_key_aborts_initiation` test in `noise::mod` for the
-    // corresponding sending direction (an initiator refusing to emit an initiation).
+    // The sending direction is handled differently: a low-order peer *static*
+    // key is rejected up front when constructing a `PeerPublicKey`, so it can
+    // never reach the initiation code. See the `rejects_low_order_keys` test in
+    // `crate::key`.
     #[test]
     fn rejects_low_order_ephemeral_in_initiation() {
         let responder_private =

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -920,6 +920,37 @@ impl Handshake {
     }
 }
 
+/// Every low-order point on Curve25519, decoded from the same base64 form as the
+/// WireGuard kernel selftest (`tools/testing/selftests/wireguard/netns.sh`). Any
+/// clamped scalar multiplied by one of these yields the all-zero
+/// (non-contributory) shared secret.
+///
+/// This is every low-order point on the curve, but not every 32-byte input that
+/// produces an all-zero DH result (Curve25519's twist has its own low-order
+/// points). That is fine: the list is test-only, and the production check
+/// ([`dh::SharedSecret`]) rejects on the all-zero output itself, catching those
+/// too.
+#[cfg(test)]
+pub(crate) fn low_order_keys() -> [[u8; 32]; 7] {
+    use base64::Engine as _;
+    [
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "4Ot6fDtBuK4WVuP68Z/EatoJjeucMrH9hmIFFl9JuAA=",
+        "X5yVvKNQjCSx0LFVnIPvWwREXMRYHI6G2CJO3dCfEVc=",
+        "7P///////////////////////////////////////38=",
+        "7f///////////////////////////////////////38=",
+        "7v///////////////////////////////////////38=",
+    ]
+    .map(|encoded| {
+        base64::prelude::BASE64_STANDARD
+            .decode(encoded)
+            .expect("valid base64")
+            .try_into()
+            .expect("32-byte key")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -976,5 +1007,57 @@ mod tests {
 
         aead_chacha20_open(&mut [], &key, counter, &encrypted_nothing, &aad)
             .expect("Should open what we just sealed");
+    }
+
+    // Build a handshake initiation that `parse_handshake_anon` accepts, sealing
+    // `encrypted_static` under the key an attacker derives from a low-order
+    // ephemeral (whose `es` DH is the publicly-known all-zero value). This
+    // replays the `parse_handshake_anon` key derivation.
+    fn craft_anon_initiation_with_low_order_ephemeral(
+        responder_public: &x25519::PublicKey,
+        ephemeral: [u8; 32],
+    ) -> WgHandshakeInit {
+        let mut chaining_key = INITIAL_CHAIN_KEY;
+        let mut hash = b2s_hash(&INITIAL_CHAIN_HASH, responder_public.as_bytes());
+        hash = b2s_hash(&hash, &ephemeral);
+        chaining_key = b2s_hmac(&b2s_hmac(&chaining_key, &ephemeral), &[0x01]);
+        // es is all-zero for a low-order ephemeral.
+        let temp = b2s_hmac(&chaining_key, &[0u8; 32]);
+        chaining_key = b2s_hmac(&temp, &[0x01]);
+        let key = b2s_hmac2(&temp, &chaining_key, &[0x02]);
+
+        let mut packet = WgHandshakeInit::new();
+        packet.unencrypted_ephemeral = ephemeral;
+        aead_chacha20_seal(
+            packet.encrypted_static.as_mut_bytes(),
+            &key,
+            0,
+            &[7u8; 32],
+            &hash,
+        );
+        packet
+    }
+
+    // Tests the receiving direction: a remote initiator sends us a low-order public ephemeral key.
+    //
+    // Such an ephemeral yields a non-contributory (all-zero) DH; it must be
+    // rejected.
+    //
+    // See the `low_order_peer_static_key_aborts_initiation` test in `noise::mod` for the
+    // corresponding sending direction (an initiator refusing to emit an initiation).
+    #[test]
+    fn rejects_low_order_ephemeral_in_initiation() {
+        let responder_private = x25519::StaticSecret::random_from_rng(rand_core::OsRng);
+        let responder_public = x25519::PublicKey::from(&responder_private);
+
+        for low_order in low_order_keys() {
+            let packet =
+                craft_anon_initiation_with_low_order_ephemeral(&responder_public, low_order);
+            let result = parse_handshake_anon(&responder_private, &responder_public, &packet);
+            assert!(
+                result.is_err(),
+                "point {low_order:02x?}: handshake must be rejected, got {result:?}"
+            );
+        }
     }
 }

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -167,12 +167,11 @@ impl<R: RngCore + Send> Tunn<R> {
     pub fn set_static_private(
         &mut self,
         static_private: x25519::StaticSecret,
-        static_public: x25519::PublicKey,
         rate_limiter: Arc<RateLimiter>,
     ) {
         self.rate_limiter = rate_limiter;
         self.handshake
-            .set_static_private(dh::StaticSecret::from(static_private), static_public);
+            .set_static_private(dh::StaticSecret::from(static_private));
         for s in &mut self.sessions {
             *s = None;
         }

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -28,6 +28,7 @@ mod timers;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use zerocopy::IntoBytes;
 
+use crate::key::PeerPublicKey;
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::Handshake;
 use crate::noise::index_table::IndexTable;
@@ -91,13 +92,9 @@ pub struct Tunn<R: RngCore + Send = StdRng> {
 
 impl Tunn<StdRng> {
     /// Create a new tunnel using own private key and the peer public key.
-    ///
-    /// Note: if `peer_static_public` is a low-order (non-contributory) Curve25519
-    /// point, no error is returned here, but every handshake with this peer will
-    /// fail.
     pub fn new(
         static_private: x25519::StaticSecret,
-        peer_static_public: x25519::PublicKey,
+        peer_static_public: PeerPublicKey,
         preshared_key: Option<[u8; 32]>,
         persistent_keepalive: Option<u16>,
         index_table: IndexTable,
@@ -117,13 +114,9 @@ impl Tunn<StdRng> {
 
 impl<R: RngCore + Send> Tunn<R> {
     /// Create a new tunnel using own private key and the peer public key.
-    ///
-    /// Note: if `peer_static_public` is a low-order (non-contributory) Curve25519
-    /// point, no error is returned here, but every handshake with this peer will
-    /// fail.
     pub fn new_with_rng(
         static_private: x25519::StaticSecret,
-        peer_static_public: x25519::PublicKey,
+        peer_static_public: PeerPublicKey,
         preshared_key: Option<[u8; 32]>,
         persistent_keepalive: Option<u16>,
         index_table: IndexTable,
@@ -159,11 +152,6 @@ impl<R: RngCore + Send> Tunn<R> {
     }
 
     /// Update the private key and clear existing sessions.
-    ///
-    /// Note: this recomputes the static-static shared secret with the peer's
-    /// public key. If that key is a low-order (non-contributory) Curve25519
-    /// point, no error is returned here, but every subsequent handshake with
-    /// the peer will fail.
     pub fn set_static_private(
         &mut self,
         static_private: x25519::StaticSecret,
@@ -415,15 +403,7 @@ impl<R: RngCore + Send> Tunn<R> {
 
         let starting_new_handshake = !self.handshake.is_in_progress();
 
-        // A non-contributory (low-order) peer static key aborts the handshake
-        // here, so no initiation is sent. See [`Tunn::new`] / [`Tunn::set_static_private`].
-        let packet = match self.handshake.format_handshake_initiation() {
-            Ok(packet) => packet,
-            Err(error) => {
-                log::debug!("Not sending handshake_initiation: {error:?}");
-                return None;
-            }
-        };
+        let packet = self.handshake.format_handshake_initiation();
         log::debug!("Sending handshake_initiation");
 
         if starting_new_handshake {
@@ -565,7 +545,7 @@ mod tests {
         let rate_limiter = Arc::new(RateLimiter::new(&my_public_key, HANDSHAKE_RATE_LIMIT));
         let my_tun = Tunn::new(
             my_secret_key,
-            their_public_key,
+            PeerPublicKey::new(their_public_key).unwrap(),
             None,
             None,
             IndexTable::from_os_rng(),
@@ -575,7 +555,7 @@ mod tests {
         let rate_limiter = Arc::new(RateLimiter::new(&their_public_key, HANDSHAKE_RATE_LIMIT));
         let their_tun = Tunn::new(
             their_secret_key,
-            my_public_key,
+            PeerPublicKey::new(my_public_key).unwrap(),
             None,
             None,
             IndexTable::from_os_rng(),
@@ -667,40 +647,6 @@ mod tests {
     fn handshake_init() {
         let (mut my_tun, _their_tun) = create_two_tuns();
         let _init = create_handshake_init(&mut my_tun);
-    }
-
-    // Tests the sending direction: an initiator generating a handshake
-    // initiation. The low-order key here stands in for the peer's configured
-    // static public key.
-    //
-    // Such a static key yields a non-contributory (all-zero) DH, so the
-    // initiator must never complete a handshake: it must emit no initiation.
-    // Checked for every known low-order point, not just the all-zero one.
-    //
-    // See `rejects_low_order_ephemeral_in_initiation` in `noise::handshake` for
-    // the receiving direction (a responder rejecting an incoming initiation).
-    #[test]
-    fn low_order_peer_static_key_aborts_initiation() {
-        for low_order in crate::noise::handshake::low_order_keys() {
-            let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
-            let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
-            let low_order_peer = x25519_dalek::PublicKey::from(low_order);
-
-            let rate_limiter = Arc::new(RateLimiter::new(&my_public_key, HANDSHAKE_RATE_LIMIT));
-            let mut tun = Tunn::new(
-                my_secret_key,
-                low_order_peer,
-                None,
-                None,
-                IndexTable::from_os_rng(),
-                rate_limiter,
-            );
-
-            assert!(
-                tun.format_handshake_initiation(false).is_none(),
-                "point {low_order:02x?}: initiation must be aborted for a non-contributory peer static key"
-            );
-        }
     }
 
     #[test]
@@ -1052,7 +998,7 @@ mod tests {
         let rate_limiter = Arc::new(RateLimiter::new(&my_public_key, HANDSHAKE_RATE_LIMIT));
         let mut my_tun = Tunn::new_with_rng(
             my_secret_key,
-            their_public_key,
+            PeerPublicKey::new(their_public_key).unwrap(),
             None,
             None,
             IndexTable::from_os_rng(),

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -21,6 +21,7 @@ pub mod index_table;
 /// Rate limiting for handshake initiation packets.
 pub mod rate_limiter;
 
+pub(crate) mod dh;
 mod session;
 mod timers;
 
@@ -90,6 +91,10 @@ pub struct Tunn<R: RngCore + Send = StdRng> {
 
 impl Tunn<StdRng> {
     /// Create a new tunnel using own private key and the peer public key.
+    ///
+    /// Note: if `peer_static_public` is a low-order (non-contributory) Curve25519
+    /// point, no error is returned here, but every handshake with this peer will
+    /// fail.
     pub fn new(
         static_private: x25519::StaticSecret,
         peer_static_public: x25519::PublicKey,
@@ -112,6 +117,10 @@ impl Tunn<StdRng> {
 
 impl<R: RngCore + Send> Tunn<R> {
     /// Create a new tunnel using own private key and the peer public key.
+    ///
+    /// Note: if `peer_static_public` is a low-order (non-contributory) Curve25519
+    /// point, no error is returned here, but every handshake with this peer will
+    /// fail.
     pub fn new_with_rng(
         static_private: x25519::StaticSecret,
         peer_static_public: x25519::PublicKey,
@@ -121,12 +130,11 @@ impl<R: RngCore + Send> Tunn<R> {
         rate_limiter: Arc<RateLimiter>,
         jitter_rng: R,
     ) -> Self {
-        let static_public = x25519::PublicKey::from(&static_private);
+        let static_private = dh::StaticSecret::from(static_private);
 
         Tunn {
             handshake: Handshake::new(
                 static_private,
-                static_public,
                 peer_static_public,
                 index_table,
                 preshared_key,
@@ -151,6 +159,11 @@ impl<R: RngCore + Send> Tunn<R> {
     }
 
     /// Update the private key and clear existing sessions.
+    ///
+    /// Note: this recomputes the static-static shared secret with the peer's
+    /// public key. If that key is a low-order (non-contributory) Curve25519
+    /// point, no error is returned here, but every subsequent handshake with
+    /// the peer will fail.
     pub fn set_static_private(
         &mut self,
         static_private: x25519::StaticSecret,
@@ -159,7 +172,7 @@ impl<R: RngCore + Send> Tunn<R> {
     ) {
         self.rate_limiter = rate_limiter;
         self.handshake
-            .set_static_private(static_private, static_public);
+            .set_static_private(dh::StaticSecret::from(static_private), static_public);
         for s in &mut self.sessions {
             *s = None;
         }
@@ -403,7 +416,15 @@ impl<R: RngCore + Send> Tunn<R> {
 
         let starting_new_handshake = !self.handshake.is_in_progress();
 
-        let packet = self.handshake.format_handshake_initiation();
+        // A non-contributory (low-order) peer static key aborts the handshake
+        // here, so no initiation is sent. See [`Tunn::new`] / [`Tunn::set_static_private`].
+        let packet = match self.handshake.format_handshake_initiation() {
+            Ok(packet) => packet,
+            Err(error) => {
+                log::debug!("Not sending handshake_initiation: {error:?}");
+                return None;
+            }
+        };
         log::debug!("Sending handshake_initiation");
 
         if starting_new_handshake {

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -649,6 +649,40 @@ mod tests {
         let _init = create_handshake_init(&mut my_tun);
     }
 
+    // Tests the sending direction: an initiator generating a handshake
+    // initiation. The low-order key here stands in for the peer's configured
+    // static public key.
+    //
+    // Such a static key yields a non-contributory (all-zero) DH, so the
+    // initiator must never complete a handshake: it must emit no initiation.
+    // Checked for every known low-order point, not just the all-zero one.
+    //
+    // See `rejects_low_order_ephemeral_in_initiation` in `noise::handshake` for
+    // the receiving direction (a responder rejecting an incoming initiation).
+    #[test]
+    fn low_order_peer_static_key_aborts_initiation() {
+        for low_order in crate::noise::handshake::low_order_keys() {
+            let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
+            let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
+            let low_order_peer = x25519_dalek::PublicKey::from(low_order);
+
+            let rate_limiter = Arc::new(RateLimiter::new(&my_public_key, HANDSHAKE_RATE_LIMIT));
+            let mut tun = Tunn::new(
+                my_secret_key,
+                low_order_peer,
+                None,
+                None,
+                IndexTable::from_os_rng(),
+                rate_limiter,
+            );
+
+            assert!(
+                tun.format_handshake_initiation(false).is_none(),
+                "point {low_order:02x?}: initiation must be aborted for a non-contributory peer static key"
+            );
+        }
+    }
+
     #[test]
     // Verify that a valid hanshake is accepted by two linked peers when rate limiting is not
     // applied.


### PR DESCRIPTION
Adds a check that rejects non-contributory (low-order / all-zero) X25519 Diffie-Hellman results during the Noise handshake. Every DH is now guarded at handshake time: the ephemeral DHs (es, ee, se) and the
precomputed static-static (ss). A non-contributory result aborts the handshake (`WireGuardError::InvalidSharedSecret`); on the initiator side this means no initiation is emitted.

Previously no DH output was validated, so a low-order peer key (static or ephemeral) was accepted and fed into key derivation.

## Why

A low-order input point collapses the DH to a fixed, publicly-known value, contributing no entropy. The [Noise spec (§12.1)](https://noiseprotocol.org/noise.html#the-25519-dh-functions) permits but actually discourages this all-zero check, and the WireGuard whitepaper is silent - but both reference implementations (Linux kernel and wireguard-go) perform it as an extra hardening measure, so we match them. This is hardening / kernel parity, not a remotely exploitable confidentiality break.

Links to where the Linux kernel and wireguard-go implementations implement this check:
* The kernel ephemeral es/ee/se check: https://github.com/torvalds/linux/blob/acb7500801e98639f6d8c2d796ed9f64cba83d3a/drivers/net/wireguard/noise.c#L412
* The kernel static-static (ss) zero check: https://github.com/torvalds/linux/blob/acb7500801e98639f6d8c2d796ed9f64cba83d3a/drivers/net/wireguard/noise.c#L425
* The wireguard-go ephemeral key check: https://github.com/WireGuard/wireguard-go/blob/ecfc5a8d54462e18e13c72173e2623d16d8e25a0/device/noise-helpers.go#L104-L106
* The wireguard-go static-static (ss) checks at handshake time: https://github.com/WireGuard/wireguard-go/blob/ecfc5a8d54462e18e13c72173e2623d16d8e25a0/device/noise-protocol.go#L314-L316
* The kernel commit that deferred the all-zero check to handshake time: https://github.com/torvalds/linux/commit/11a7686aa99c7fe4b3f80f6dcccd54129817984d

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/142)
<!-- Reviewable:end -->
