### PR TITLE
Enforce `Reject-After-Messages` limit on transport data counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not send persistent keepalives if tunnel is active.
 
 ### Security
+- Enforce the `Reject-After-Messages` limit on the transport data counter, so a
+  session is retired before its AEAD nonce can wrap and repeat.
+
 #### Linux
 - Fix a remotely triggerable denial of service in the `recvmmsg` receive path.
   An oversized incoming UDP datagram (larger than the receive buffer) panicked

--- a/gotatun/src/device/daita/actions.rs
+++ b/gotatun/src/device/daita/actions.rs
@@ -238,8 +238,8 @@ where
             .fetch_add(mtu as usize, atomic::Ordering::SeqCst);
         peer.tunnel
             .encapsulate_with_session(self.create_decoy_packet(mtu))
-            // Encapsulate can only fail when there is no session, just drop the decoy packet in
-            // that case
+            // Encapsulation only fails when there is no usable session (none established, or the
+            // current one hit its message limit); just drop the decoy packet in that case.
             .map_err(|_| ErrorAction::Ignore(IgnoreReason::NoSession))
     }
 

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -207,12 +207,13 @@ impl<R: RngCore + Send> Tunn<R> {
 
     /// Encapsulate a single packet into a [`WgData`].
     ///
-    /// Returns `Err(original_packet)` if there is no active session.
+    /// Returns `Err(original_packet)` if there is no active session, or if the active session's
+    /// sending counter has reached `REJECT_AFTER_MESSAGES`.
     pub fn encapsulate_with_session(&mut self, packet: Packet) -> Result<Packet<WgData>, Packet> {
         let current = self.current;
         if let Some(ref session) = self.sessions[current % N_SESSIONS] {
             // Send the packet using an established session
-            let packet = session.format_packet_data(packet);
+            let packet = session.format_packet_data(packet)?;
             self.timer_tick(TimerName::TimeLastPacketSent);
             // Exclude Keepalive packets from timer update.
             if !packet.is_keepalive() {
@@ -277,7 +278,9 @@ impl<R: RngCore + Send> Tunn<R> {
         let mut p = p.into_bytes();
         p.truncate(0);
 
-        let keepalive_packet = session.format_packet_data(p);
+        let keepalive_packet = session
+            .format_packet_data(p)
+            .expect("a freshly established session's counter cannot be exhausted");
         // Store new session in next slot
         let slot = self.next_session_slot();
         self.put_session(slot, session);
@@ -797,6 +800,35 @@ mod tests {
         // Advance past REKEY_TIMEOUT + max possible jitter to guarantee the retry fires.
         MockClock::advance(REKEY_TIMEOUT + MAX_JITTER + Duration::from_millis(1));
         update_timer_results_in_handshake(&mut my_tun)
+    }
+
+    /// The send path must use the last in-limit counter (REJECT_AFTER_MESSAGES - 1) but then
+    /// refuse to encapsulate any more data (which would reuse an AEAD nonce), beginning a fresh
+    /// handshake instead.
+    #[test]
+    fn outgoing_packet_refused_after_message_limit() {
+        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake();
+
+        // Fast-forward the established session to its last usable counter value.
+        let slot = my_tun.current % N_SESSIONS;
+        my_tun.sessions[slot]
+            .as_ref()
+            .expect("session established after handshake")
+            .set_sending_key_counter(session::REJECT_AFTER_MESSAGES - 1);
+
+        // The last in-limit packet is still encapsulated and sent.
+        let last = my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None);
+        assert!(
+            matches!(last, Some(WgKind::Data(_))),
+            "expected the last in-limit packet to be sent, got {last:?}"
+        );
+
+        // The next packet hits the limit: no data is sent, a new handshake begins instead.
+        let over = my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None);
+        assert!(
+            matches!(over, Some(WgKind::HandshakeInit(_))),
+            "expected a new handshake instead of an encapsulated data packet, got {over:?}"
+        );
     }
 
     #[test]

--- a/gotatun/src/noise/session.rs
+++ b/gotatun/src/noise/session.rs
@@ -45,6 +45,13 @@ const WORD_SIZE: u64 = 64;
 const N_WORDS: u64 = 16; // Suffice to reorder 64*16 = 1024 packets; can be increased at will
 const N_BITS: u64 = WORD_SIZE * N_WORDS;
 
+/// The maximum number of transport data messages that may be sent or received under a single
+/// session key, per section 6.2 of the [whitepaper](https://www.wireguard.com/papers/wireguard.pdf)
+/// (`Reject-After-Messages = 2^64 - 2^13 - 1`).
+/// Refusing to use a counter at or beyond this value guarantees the 64-bit AEAD nonce can never
+/// wrap and reuse a nonce with the same key.
+pub(super) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1 << 13);
+
 #[derive(Debug, Clone, Default)]
 struct ReceivingKeyCounterValidator {
     /// In order to avoid replays while allowing for some reordering of the packets, we keep a
@@ -195,8 +202,24 @@ impl Session {
         ret
     }
 
+    /// Test-only: fast-forward the sending counter so the `REJECT_AFTER_MESSAGES` limit can be
+    /// exercised without actually sending billions of packets.
+    #[cfg(test)]
+    pub(super) fn set_sending_key_counter(&self, value: u64) {
+        self.sending_key_counter.store(value, Ordering::Relaxed);
+    }
+
     /// Encapsulate `packet` into a [`WgData`].
-    pub(super) fn format_packet_data(&self, packet: Packet) -> Packet<WgData> {
+    ///
+    /// Returns `Err(packet)` (the original, un-encapsulated packet) once the sending counter has
+    /// reached `REJECT_AFTER_MESSAGES`: the session must then be replaced by a fresh handshake
+    /// before more transport data can be sent, so the AEAD nonce can never wrap.
+    pub(super) fn format_packet_data(&self, packet: Packet) -> Result<Packet<WgData>, Packet> {
+        // Check before incrementing so an exhausted counter is never advanced (and thus can never
+        // wrap back around to a previously used value).
+        if self.sending_key_counter.load(Ordering::Relaxed) >= REJECT_AFTER_MESSAGES {
+            return Err(packet);
+        }
         let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed);
 
         let len = WgData::OVERHEAD + packet.len();
@@ -240,7 +263,7 @@ impl Session {
             unreachable!("is a wireguard data packet");
         };
 
-        packet
+        Ok(packet)
     }
 
     /// Decapsulate `packet` and return the decrypted data.
@@ -253,6 +276,10 @@ impl Session {
         }
 
         let counter = packet.header.counter.get();
+
+        if counter >= REJECT_AFTER_MESSAGES {
+            return Err(WireGuardError::ConnectionExpired);
+        }
 
         // Don't reuse counters, in case this is a replay attack we want to quickly check the
         // counter without running expensive decryption
@@ -293,6 +320,48 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::noise::index_table::IndexTable;
+
+    /// Build a `Session` with throwaway keys and a real receiving index.
+    fn test_session() -> Session {
+        let table: IndexTable = IndexTable::from_os_rng();
+        Session::new(table.new_index(), 0, [0u8; 32], [0u8; 32])
+    }
+
+    /// Craft a (cryptographically invalid) `WgData` packet with a chosen receiver index and
+    /// counter, for exercising the receive-path checks that run before decryption.
+    fn make_data_packet(receiver_idx: u32, counter: u64) -> Packet<WgData> {
+        let mut buf = Packet::from_bytes(BytesMut::zeroed(WgData::OVERHEAD));
+        let data = WgData::mut_from_bytes(buf.buf_mut()).expect("buffer is WgData::OVERHEAD");
+        data.header = WgDataHeader::new()
+            .with_receiver_idx(receiver_idx)
+            .with_counter(counter);
+        let WgKind::Data(packet) = buf.try_into_wg().expect("is a wireguard packet") else {
+            unreachable!("is a wireguard data packet");
+        };
+        packet
+    }
+
+    /// The receive path must reject a counter at/beyond REJECT_AFTER_MESSAGES before decryption,
+    /// while a counter just below the limit is allowed past that check (and fails later at AEAD).
+    #[test]
+    fn test_receive_rejects_counter_at_reject_after_messages() {
+        let session = test_session();
+        let recv_idx = session.receiving_index.value();
+
+        let over_limit = make_data_packet(recv_idx, REJECT_AFTER_MESSAGES);
+        assert!(matches!(
+            session.receive_packet_data(over_limit),
+            Err(WireGuardError::ConnectionExpired)
+        ));
+
+        let in_limit = make_data_packet(recv_idx, REJECT_AFTER_MESSAGES - 1);
+        assert!(matches!(
+            session.receive_packet_data(in_limit),
+            Err(WireGuardError::InvalidAeadTag)
+        ));
+    }
+
     #[test]
     fn test_replay_counter() {
         let mut c: ReceivingKeyCounterValidator = Default::default();


### PR DESCRIPTION
WireGuard whitepaper (§6.2) requires retiring a session key after `Reject-After-Messages` (2^64 - 2^13 - 1) transport messages, so the 64-bit counter used as the ChaCha20-Poly1305 nonce can never wrap and repeat a nonce under the same key. GotaTun defined no such limit and enforced it on neither the send nor the receive path.

Reaching this limit is virtually impossible in practice: wrapping the counter within a session's 180 s `Reject-After-Time` lifetime would take on the order of 10^17 packets per second. The value that this limit provides is that it guarantees nonce uniqueness from the counter alone, independent of whether the session-expiry timers actually fire.

Even if practically impossible to exploit, this is defense in depth, and required in order to implement the specification correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/143)
<!-- Reviewable:end -->
