### PR TITLE
Fix timer inaccuracies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   meant that two idling GotaTun peers could keep pinging each other with passive keepalives.
 - The passive keepalive timer was relative to the *last sent packet*. This meant that an idle tunnel
   receiving a packet would instantly send a keepalive (instead of waiting for `KEEPALIVE-TIMEOUT`).
+- Do not send persistent keepalives if tunnel is active.
 
 ### Security
 #### Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add missing jitter for handshakes initiated due to not receiving any packets.
+
 ### Security
 #### Linux
 - Fix a remotely triggerable denial of service in the `recvmmsg` receive path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Add missing jitter for handshakes initiated due to not receiving any packets.
+- Passive keepalives were triggered by received keepalives, not just non-empty data packets. This
+  meant that two idling GotaTun peers could keep pinging each other with passive keepalives.
+- The passive keepalive timer was relative to the *last sent packet*. This meant that an idle tunnel
+  receiving a packet would instantly send a keepalive (instead of waiting for `KEEPALIVE-TIMEOUT`).
 
 ### Security
 #### Linux

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -324,7 +324,9 @@ impl<R: RngCore + Send> Tunn<R> {
     fn handle_data(&mut self, packet: Packet<WgData>) -> Result<TunnResult, WireGuardError> {
         let decapsulated_packet = self.decapsulate_with_session(packet)?;
 
-        self.timer_tick(TimerName::TimeLastDataPacketReceived);
+        if !decapsulated_packet.is_empty() {
+            self.timer_tick(TimerName::TimeLastDataPacketReceived);
+        }
 
         Ok(TunnResult::WriteToTunnel(decapsulated_packet))
     }
@@ -926,6 +928,61 @@ mod tests {
             matches!(my_tun.update_timers(), Ok(Some(WgKind::HandshakeInit(..)))),
             "retry should fire at REKEY_TIMEOUT + jitter"
         );
+    }
+
+    /// Verify that a received keepalive is not answered with a passive keepalive.
+    ///
+    /// Only *data* packets must arm the passive keepalive timer. If keepalives counted as
+    /// received data, two idle peers would exchange keepalives indefinitely.
+    #[test]
+    #[cfg(feature = "mock_instant")]
+    fn keepalive_is_not_answered_with_keepalive() {
+        const KEEPALIVE: Duration = Duration::from_secs(10); // KEEPALIVE_TIMEOUT
+
+        MockClock::set_time(Duration::ZERO);
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
+
+        MockClock::advance(Duration::from_secs(1));
+        assert!(matches!(my_tun.update_timers(), Ok(None)));
+        assert!(matches!(their_tun.update_timers(), Ok(None)));
+
+        // Send a data packet at t = 1 s, leaving it unanswered.
+        let data = my_tun
+            .handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None)
+            .expect("expected encapsulated packet");
+        let result = their_tun.handle_incoming_packet(data);
+        assert!(matches!(result, TunnResult::WriteToTunnel(..)));
+
+        MockClock::advance(KEEPALIVE - Duration::from_millis(1));
+        let nothing = their_tun
+            .update_timers()
+            .expect("update_timers should succeed");
+        assert!(nothing.is_none(), "expect no packet or keepalive yet");
+
+        // The peer answers with a passive keepalive KEEPALIVE after the data arrived.
+        MockClock::advance(Duration::from_millis(1));
+        let packet = their_tun
+            .update_timers()
+            .expect("update_timers should succeed")
+            .expect("expected some timer packet");
+        assert!(
+            matches!(&packet, WgKind::Data(p) if p.is_keepalive()),
+            "expected keepalive packet, got {packet:?}"
+        );
+
+        assert!(matches!(my_tun.update_timers(), Ok(None)));
+        let result = my_tun.handle_incoming_packet(packet);
+        assert!(matches!(result, TunnResult::WriteToTunnel(p) if p.is_empty()));
+
+        // The received keepalive must not be answered with another keepalive, no matter
+        // how long we wait.
+        for _ in 0..30 {
+            MockClock::advance(Duration::from_secs(1));
+            assert!(
+                matches!(my_tun.update_timers(), Ok(None)),
+                "keepalive must not be answered with a keepalive"
+            );
+        }
     }
 
     /// Verify that one IP hitting the rate limit does not affect a different IP.

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -282,7 +282,6 @@ impl<R: RngCore + Send> Tunn<R> {
         log::debug!("Received cookie_reply: {}", p.receiver_idx);
 
         self.handshake.receive_cookie_reply(p)?;
-        self.timer_tick(TimerName::TimeLastPacketReceived);
         self.timer_tick(TimerName::TimeCookieReceived);
 
         Ok(TunnResult::Done)

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -46,9 +46,9 @@ pub enum TimerName {
     TimeLastPacketReceived,
     /// Time we last send a packet
     TimeLastPacketSent,
-    /// Time we last received and authenticated a DATA packet
+    /// Time we last received a valid [`crate::packet::WgData`] packet, except keepalives
     TimeLastDataPacketReceived,
-    /// Time we last send a DATA packet
+    /// Time we last sent a [`crate::packet::WgData`] packet, except keepalives
     TimeLastDataPacketSent,
     /// Time we last received a cookie
     TimeCookieReceived,

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -76,6 +76,9 @@ pub struct Timers {
     /// Jitter added to the current [`REKEY_TIMEOUT`] interval.
     /// This should be randomized on each handshake initiation.
     pub(super) handshake_jitter: Duration,
+    /// Jitter added to the new-handshake timeout (`KEEPALIVE_TIMEOUT + REKEY_TIMEOUT`).
+    /// This should be randomized each time the new-handshake timer is armed.
+    new_handshake_jitter: Duration,
 }
 
 impl Timers {
@@ -89,6 +92,7 @@ impl Timers {
             want_handshake: Default::default(),
             persistent_keepalive: usize::from(persistent_keepalive.unwrap_or(0)),
             handshake_jitter: Duration::ZERO,
+            new_handshake_jitter: Duration::ZERO,
         }
     }
 
@@ -106,6 +110,7 @@ impl Timers {
         self.want_handshake = None;
         self.want_keepalive = false;
         self.handshake_jitter = Duration::ZERO;
+        self.new_handshake_jitter = Duration::ZERO;
     }
 
     /// Compute the time elapsed since [`Self::time_started`] based on [`Instant::now`].
@@ -145,7 +150,10 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                 self.timers.want_keepalive = false;
             }
             TimeLastDataPacketSent => {
-                self.timers.want_handshake.get_or_insert(time);
+                if self.timers.want_handshake.is_none() {
+                    self.timers.new_handshake_jitter = self.next_jitter();
+                    self.timers.want_handshake = Some(time);
+                }
             }
             _ => {}
         }
@@ -296,7 +304,8 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                 // packet after from that peer for `(KEEPALIVE + REKEY_TIMEOUT)`,
                 // we initiate a new handshake.
                 if let Some(since) = self.timers.want_handshake
-                    && now.saturating_sub(since) >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
+                    && now.saturating_sub(since)
+                        >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT + self.timers.new_handshake_jitter
                 {
                     log::trace!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -149,6 +149,9 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                 if self.timers.want_keepalive.is_none() {
                     self.timers.want_keepalive = Some(time);
                 }
+                // The Linux kernel schedules an extra keepalive here if one is already queued:
+                // https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L157-L166
+                // This seems unnecessary?
             }
             TimeLastPacketSent => {
                 self.timers.want_keepalive = None;

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -72,7 +72,7 @@ pub struct Timers {
     want_keepalive: Option<Duration>,
     /// First data packet sent without hearing back
     want_handshake: Option<Duration>,
-    persistent_keepalive: usize,
+    persistent_keepalive: Option<Duration>,
     /// Jitter added to the current [`REKEY_TIMEOUT`] interval.
     /// This should be randomized on each handshake initiation.
     pub(super) handshake_jitter: Duration,
@@ -90,7 +90,9 @@ impl Timers {
             session_timers: Default::default(),
             want_keepalive: Default::default(),
             want_handshake: Default::default(),
-            persistent_keepalive: usize::from(persistent_keepalive.unwrap_or(0)),
+            persistent_keepalive: persistent_keepalive
+                .filter(|&s| s > 0)
+                .map(|s| Duration::from_secs(s.into())),
             handshake_jitter: Duration::ZERO,
             new_handshake_jitter: Duration::ZERO,
         }
@@ -144,6 +146,10 @@ impl<R: rand::RngCore + Send> Tunn<R> {
         match timer_name {
             TimeLastPacketReceived => {
                 self.timers.want_handshake = None;
+
+                // Reset persistent keepalive timer for any authenticated packet
+                // Ref: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L215-L220
+                self.timers[TimePersistentKeepalive] = time;
             }
             TimeLastDataPacketReceived => {
                 if self.timers.want_keepalive.is_none() {
@@ -155,6 +161,10 @@ impl<R: rand::RngCore + Send> Tunn<R> {
             }
             TimeLastPacketSent => {
                 self.timers.want_keepalive = None;
+
+                // Reset persistent keepalive timer for any authenticated packet
+                // Ref: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L215-L220
+                self.timers[TimePersistentKeepalive] = time;
             }
             TimeLastDataPacketSent => {
                 if self.timers.want_handshake.is_none() {
@@ -330,9 +340,9 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                     }
 
                     // Persistent KEEPALIVE
-                    if persistent_keepalive > 0
-                        && (now - self.timers[TimePersistentKeepalive]
-                            >= Duration::from_secs(persistent_keepalive as _))
+                    if let Some(persistent_keepalive) = persistent_keepalive
+                        && (now.saturating_sub(self.timers[TimePersistentKeepalive])
+                            >= persistent_keepalive)
                     {
                         log::trace!("KEEPALIVE(PERSISTENT_KEEPALIVE)");
                         self.timer_tick(TimePersistentKeepalive);
@@ -371,26 +381,25 @@ impl<R: rand::RngCore + Send> Tunn<R> {
 
     /// Get the persistent keepalive interval in seconds.
     ///
-    /// Returns `None` if persistent keepalive is disabled (set to 0).
+    /// Returns `None` if persistent keepalive is disabled.
     pub fn persistent_keepalive(&self) -> Option<u16> {
-        let keepalive = self.timers.persistent_keepalive;
-
-        if keepalive > 0 {
-            Some(keepalive as u16)
-        } else {
-            None
-        }
+        self.timers
+            .persistent_keepalive
+            .map(|keepalive| keepalive.as_secs() as u16)
+            .filter(|&keepalive| keepalive > 0)
     }
 
     /// Set the persistent keepalive interval in seconds.
     ///
     /// Pass `None` or `Some(0)` to disable persistent keepalive.
     pub fn set_persistent_keepalive(&mut self, seconds: Option<u16>) {
-        self.timers.persistent_keepalive = usize::from(seconds.unwrap_or(0));
-
-        // Reset timer if we disable persistent keepalive
-        if self.timers.persistent_keepalive == 0 {
+        self.timers.persistent_keepalive = seconds
+            .filter(|&s| s > 0)
+            .map(|s| Duration::from_secs(s.into()));
+        if self.timers.persistent_keepalive.is_none() {
             self.timers[TimePersistentKeepalive] = Duration::ZERO;
+        } else {
+            self.timers[TimePersistentKeepalive] = self.timers[TimeCurrent];
         }
     }
 }

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -14,7 +14,6 @@ use super::errors::WireGuardError;
 use crate::noise::Tunn;
 use crate::packet::WgKind;
 
-use std::mem;
 use std::ops::{Index, IndexMut};
 use std::time::Duration;
 
@@ -68,8 +67,9 @@ pub struct Timers {
     time_started: Instant,
     timers: [Duration; TimerName::Top as usize],
     pub(super) session_timers: [Duration; super::N_SESSIONS],
-    /// Did we receive data without sending anything back?
-    want_keepalive: bool,
+    /// Time the first data packet was received without us sending anything back, if any.
+    /// A passive keepalive is due `KEEPALIVE_TIMEOUT` after this time.
+    want_keepalive: Option<Duration>,
     /// First data packet sent without hearing back
     want_handshake: Option<Duration>,
     persistent_keepalive: usize,
@@ -108,7 +108,7 @@ impl Timers {
             *t = now;
         }
         self.want_handshake = None;
-        self.want_keepalive = false;
+        self.want_keepalive = None;
         self.handshake_jitter = Duration::ZERO;
         self.new_handshake_jitter = Duration::ZERO;
     }
@@ -143,11 +143,15 @@ impl<R: rand::RngCore + Send> Tunn<R> {
 
         match timer_name {
             TimeLastPacketReceived => {
-                self.timers.want_keepalive = true;
                 self.timers.want_handshake = None;
             }
+            TimeLastDataPacketReceived => {
+                if self.timers.want_keepalive.is_none() {
+                    self.timers.want_keepalive = Some(time);
+                }
+            }
             TimeLastPacketSent => {
-                self.timers.want_keepalive = false;
+                self.timers.want_keepalive = None;
             }
             TimeLastDataPacketSent => {
                 if self.timers.want_handshake.is_none() {
@@ -221,7 +225,6 @@ impl<R: rand::RngCore + Send> Tunn<R> {
         // Load timers only once:
         let session_established = self.timers[TimeSessionEstablished];
         let handshake_started = self.timers[TimeLastHandshakeStarted];
-        let aut_packet_sent = self.timers[TimeLastPacketSent];
         let data_packet_received = self.timers[TimeLastDataPacketReceived];
         let data_packet_sent = self.timers[TimeLastDataPacketSent];
         let persistent_keepalive = self.timers.persistent_keepalive;
@@ -313,14 +316,14 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                 }
 
                 if !handshake_initiation_required {
-                    // If a packet has been received from a given peer, but we have not sent one
-                    // back to the given peer in KEEPALIVE ms, we send an empty packet.
-                    if data_packet_received > aut_packet_sent
-                        && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
-                        && mem::replace(&mut self.timers.want_keepalive, false)
+                    // If a data packet has been received from a given peer, but we have not sent
+                    // one back to the given peer in KEEPALIVE ms, we send an empty packet.
+                    if let Some(since) = self.timers.want_keepalive
+                        && now.saturating_sub(since) >= KEEPALIVE_TIMEOUT
                     {
                         log::trace!("KEEPALIVE(KEEPALIVE_TIMEOUT)");
                         keepalive_required = true;
+                        self.timers.want_keepalive = None;
                     }
 
                     // Persistent KEEPALIVE


### PR DESCRIPTION
PR fixes three slight deviations from spec/kernel WG:
- Handshake initiation caused by not receiving packets was missing jitter. (Probably does not matter - fixed for completeness's sake.)

    For reference, in the Linux kernel, jitter is added: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L19-L21

    https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L148-L154

- The passive keepalive timeout was triggered by received keepalives, not just non-empty data packets. This means two peers would keep pinging each other with passive keepalives instead of idling.

    For reference, in the Linux kernel, `wg_timers_data_received` is only called when non-keepalive packets are sent: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/receive.c#L357-L365

    This is pretty important. WG is meant to be quiet if nothing is happening.

- The passive keepalive timeout was measured from *last sent packet*. This means an idle tunnel receiving a packet would instantly send a keepalive (instead of waiting 10 s).

    As per the WireGuard spec (6.5), a peer should send a passive keepalive if it receives authenticated data but does not itself send anything back for `KEEPALIVE-TIMEOUT` seconds.

And some other minor stuff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/144)
<!-- Reviewable:end -->
