### PR TITLE
Fix panic on Linux in UDP receive path by growing buffer on large incoming datagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+#### Linux
+- Fix a remotely triggerable denial of service in the `recvmmsg` receive path.
+  An oversized incoming UDP datagram (larger than the receive buffer) panicked
+  the receive task, halting all UDP reception. Both single datagrams and
+  GRO-coalesced segments were affected. Such datagrams are now dropped.
 
 
 ## [0.7.1] - 2026-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a remotely triggerable denial of service in the `recvmmsg` receive path.
   An oversized incoming UDP datagram (larger than the receive buffer) panicked
   the receive task, halting all UDP reception. Both single datagrams and
-  GRO-coalesced segments were affected. Such datagrams are now dropped.
+  GRO-coalesced segments were affected. The receive buffer now grows to fit
+  them instead.
 
 
 ## [0.7.1] - 2026-05-26

--- a/gotatun/src/packet/pool.rs
+++ b/gotatun/src/packet/pool.rs
@@ -133,6 +133,43 @@ mod tests {
 
     use super::PacketBufPool;
 
+    /// Growing a packet's buffer beyond the pool's `N` (e.g. via `extend_from_slice`)
+    /// reallocates the data away from the shared allocation. Tests that the pool stays healthy
+    /// The original `N`-sized buffer is recycled via the start pointer and the pool keeps
+    /// handing out usable buffers.
+    #[test]
+    fn packet_grow_beyond_capacity() {
+        const N: usize = 4096;
+        let pool = PacketBufPool::<N>::new(1);
+
+        // Record the address of the pool's single pre-allocated buffer.
+        let buffer_ptr = {
+            let packet = pool.get();
+            let ptr = packet.as_ptr();
+            drop(packet);
+            ptr
+        };
+
+        for _ in 0..10 {
+            // The pool must hand back the original N buffer - recycled after the
+            // previous iteration grew (and so detached) its data - not a fresh one.
+            let mut packet = pool.get();
+            assert_eq!(
+                packet.as_ptr(),
+                buffer_ptr,
+                "the original N buffer must be recycled into the pool after a grow"
+            );
+            assert_eq!(packet.len(), N);
+
+            // Grow well past N; this reallocates the data onto a fresh, larger buffer,
+            // detaching it from the pooled allocation.
+            packet.buf_mut().clear();
+            packet.buf_mut().extend_from_slice(&vec![0x55u8; N * 4]);
+            assert_eq!(packet.len(), N * 4);
+            assert_ne!(packet.as_ptr(), buffer_ptr, "growing must reallocate");
+        }
+    }
+
     /// Test pre-allocation semantics of [PacketBufPool].
     #[test]
     fn pool_prealloc() {

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -217,34 +217,23 @@ mod gro {
                             // Divide packet into GRO-sized segments and copy them into Packet bufs
                             for gro_segment in iov.chunks(gro_size) {
                                 let mut buf = pool.get();
-                                // Drop segments that don't fit the pool buffer. gotatun receives
-                                // into fixed-size pool buffers. GRO segments can only be as large
-                                // as the MTU, so this can only cause drops on networks with
-                                // MTU > 4096.
-                                let Some(dst) = buf.get_mut(..gro_segment.len()) else {
-                                    log::debug!("Dropping GRO segment with size >4096 bytes");
-                                    continue;
-                                };
+                                // Copy the segment into a packet buffer, growing the buffer if the
+                                // segment is larger than the pool's buffer size.
                                 // TODO: consider splitting the iov backing buffer into multiple
                                 // BytesMut to avoid copying the data here.
-                                dst.copy_from_slice(gro_segment);
-                                buf.truncate(gro_segment.len());
-
+                                buf.buf_mut().clear();
+                                buf.buf_mut().extend_from_slice(gro_segment);
                                 packets.push((buf, source_addr));
                             }
                         } else {
                             // Single packet
                             let size = result.bytes;
                             let mut buf = pool.get();
-                            // Drop datagrams that don't fit the pool buffer. IP fragmentation
-                            // allows the source packet here to be up to 64k. But GotaTun
-                            // currently can't handle that, so we drop the packet for now.
-                            let Some(dst) = buf.get_mut(..size) else {
-                                log::debug!("Dropping incoming datagram with size >4096 bytes");
-                                continue;
-                            };
-                            dst.copy_from_slice(&iov[..size]);
-                            buf.truncate(size);
+                            // Copy the datagram into a packet buffer, growing the buffer if the
+                            // datagram is larger than the pool's buffer size (reachable via IP
+                            // fragment reassembly, up to 64k).
+                            buf.buf_mut().clear();
+                            buf.buf_mut().extend_from_slice(&iov[..size]);
                             packets.push((buf, source_addr));
                         }
                     }
@@ -271,10 +260,10 @@ mod gro {
     #[cfg(test)]
     mod tests {
         use super::UdpSocket;
-        use crate::packet::PacketBufPool;
+        use crate::packet::{Packet, PacketBufPool};
         use crate::udp::socket::SockOpt;
         use crate::udp::{UdpRecv, UdpSend};
-        use std::net::Ipv6Addr;
+        use std::net::{Ipv6Addr, SocketAddr};
         use std::time::Duration;
 
         #[tokio::test]
@@ -308,6 +297,51 @@ mod gro {
 
             assert!(!packets.is_empty(), "expected at least one IPv6 packet");
             assert_eq!(packets[0].1, sender_addr);
+        }
+
+        // A datagram larger than the pool buffer must be received in full by growing
+        // the target buffer, not dropped or truncated.
+        //
+        // Note: a single datagram is not GRO-coalesced, so this exercises the non-GRO
+        // receive branch. The GRO branch (segments larger than the buffer) is not
+        // covered here - UDP GRO does not engage on loopback.
+        #[tokio::test]
+        async fn recv_many_from_grows_for_oversized_datagram() {
+            let mut receiver =
+                UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
+            receiver.enable_udp_gro().ok();
+            let recv_addr = receiver.local_addr().unwrap();
+
+            // 10000 bytes is larger than the 4096-byte pool buffer.
+            let payload = vec![0xABu8; 10_000];
+            let sender = std::net::UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+            sender.send_to(&payload, recv_addr).unwrap();
+
+            let mut recv_pool = PacketBufPool::<4096>::new(1);
+            let mut recv_many_buf = <UdpSocket as UdpRecv>::RecvManyBuf::default();
+            let mut packets: Vec<(Packet, SocketAddr)> = Vec::new();
+
+            // The datagram is already buffered, so a single read returns it.
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                receiver.recv_many_from(&mut recv_many_buf, &mut recv_pool, &mut packets),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(packets.len(), 1, "expected exactly one packet");
+            let (packet, _) = &packets[0];
+            assert_eq!(
+                packet.len(),
+                payload.len(),
+                "oversized datagram must be received in full, not dropped or truncated"
+            );
+            assert_eq!(
+                &packet[..],
+                &payload[..],
+                "datagram must retain same content"
+            );
         }
     }
 }

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -217,9 +217,17 @@ mod gro {
                             // Divide packet into GRO-sized segments and copy them into Packet bufs
                             for gro_segment in iov.chunks(gro_size) {
                                 let mut buf = pool.get();
+                                // Drop segments that don't fit the pool buffer. gotatun receives
+                                // into fixed-size pool buffers. GRO segments can only be as large
+                                // as the MTU, so this can only cause drops on networks with
+                                // MTU > 4096.
+                                let Some(dst) = buf.get_mut(..gro_segment.len()) else {
+                                    log::debug!("Dropping GRO segment with size >4096 bytes");
+                                    continue;
+                                };
                                 // TODO: consider splitting the iov backing buffer into multiple
                                 // BytesMut to avoid copying the data here.
-                                buf[..gro_segment.len()].copy_from_slice(gro_segment);
+                                dst.copy_from_slice(gro_segment);
                                 buf.truncate(gro_segment.len());
 
                                 packets.push((buf, source_addr));
@@ -228,7 +236,14 @@ mod gro {
                             // Single packet
                             let size = result.bytes;
                             let mut buf = pool.get();
-                            buf[..size].copy_from_slice(&iov[..size]);
+                            // Drop datagrams that don't fit the pool buffer. IP fragmentation
+                            // allows the source packet here to be up to 64k. But GotaTun
+                            // currently can't handle that, so we drop the packet for now.
+                            let Some(dst) = buf.get_mut(..size) else {
+                                log::debug!("Dropping incoming datagram with size >4096 bytes");
+                                continue;
+                            };
+                            dst.copy_from_slice(&iov[..size]);
                             buf.truncate(size);
                             packets.push((buf, source_addr));
                         }

--- a/gotatun/tests/udp_oversized_datagram.rs
+++ b/gotatun/tests/udp_oversized_datagram.rs
@@ -20,10 +20,11 @@
 //! denial of service.
 //!
 //! It drives the real `UdpSocket` through the public `UdpRecv` API, so it exercises
-//! whichever receive code path is compiled in. It deliberately does not assert *how*
-//! the oversized datagram is handled (Linux drops it, the generic path truncates it);
-//! it asserts only the universal safety property: the receiver survives and still
-//! delivers a subsequent legitimate datagram.
+//! whichever receive code path is compiled in. The oversized datagram must be
+//! delivered (Linux grows the buffer to fit it; the generic path truncates it to the
+//! pool buffer) ahead of the small valid one, without crashing the receive task. The
+//! first packet's exact size is therefore platform-dependent, so the test only checks
+//! it is the larger filler datagram.
 //!
 //! Windows is excluded: its receive path reads into a 64 KiB buffer (not the 4096
 //! pool buffer), so the overflow this guards against cannot occur there, and
@@ -66,11 +67,10 @@ async fn oversized_datagram_does_not_crash_receiver() {
     let mut recv_buf = <UdpSocket as UdpRecv>::RecvManyBuf::default();
     let mut packets: Vec<(Packet, SocketAddr)> = Vec::new();
 
-    // The receiver must survive the oversized datagram (no panic) and keep working,
-    // proven by the legitimate "hello" still being delivered. A panic or a hang both
-    // fail the test - the latter via the timeout.
+    // Receive until both datagrams have arrived (they may come in one or two recvmmsg
+    // batches). A panic or a hang fails the test - the latter via the timeout.
     tokio::time::timeout(Duration::from_secs(5), async {
-        while !packets.iter().any(|(buf, _)| &buf[..] == b"hello") {
+        while packets.len() < 2 {
             receiver
                 .recv_many_from(&mut recv_buf, &mut pool, &mut packets)
                 .await
@@ -78,5 +78,22 @@ async fn oversized_datagram_does_not_crash_receiver() {
         }
     })
     .await
-    .expect("receiver must survive an oversized datagram and still deliver a valid one");
+    .expect("receiver must survive the oversized datagram and deliver both packets");
+
+    // Datagrams from one sender are delivered in order: the oversized one first, then
+    // the valid "hello". The first packet's size is platform-dependent (Linux grows the
+    // buffer to fit; the generic path truncates to the pool buffer), so only check that
+    // it is the larger filler datagram.
+    assert_eq!(packets.len(), 2, "expected exactly two packets");
+    let (first, _) = &packets[0];
+    let (second, _) = &packets[1];
+    assert!(
+        first.len() > b"hello".len() && first.iter().all(|&b| b == 0xAB),
+        "first packet must be the oversized datagram"
+    );
+    assert_eq!(
+        &second[..],
+        b"hello",
+        "second packet must be the small valid datagram"
+    );
 }

--- a/gotatun/tests/udp_oversized_datagram.rs
+++ b/gotatun/tests/udp_oversized_datagram.rs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Integration test for the UDP receive layer's handling of oversized datagrams.
+//!
+//! A remote peer can send a UDP datagram far larger than gotatun's receive pool
+//! buffer (default 4096 bytes). On loopback this is a single jumbo datagram; over a
+//! real network the same size is reachable via IP fragment reassembly. Every
+//! platform-specific `UdpSocket` receive implementation (Linux GRO `recvmmsg`,
+//! Windows `recvmsg`, and the generic tokio fallback) must handle this without
+//! crashing the receive task - otherwise a single unauthenticated packet is a remote
+//! denial of service.
+//!
+//! It drives the real `UdpSocket` through the public `UdpRecv` API, so it exercises
+//! whichever receive code path is compiled in. It deliberately does not assert *how*
+//! the oversized datagram is handled (Linux drops it, the generic path truncates it);
+//! it asserts only the universal safety property: the receiver survives and still
+//! delivers a subsequent legitimate datagram.
+//!
+//! Windows is excluded: its receive path reads into a 64 KiB buffer (not the 4096
+//! pool buffer), so the overflow this guards against cannot occur there, and
+//! `WSARecvMsg` reports an oversized datagram as a hard `WSAEMSGSIZE` error rather
+//! than truncating, which this portable harness cannot drive uniformly.
+#![cfg(not(target_os = "windows"))]
+
+use gotatun::packet::{Packet, PacketBufPool};
+use gotatun::udp::UdpRecv;
+use gotatun::udp::socket::{SockOpt, UdpSocket};
+use std::net::{Ipv6Addr, SocketAddr, UdpSocket as StdUdpSocket};
+use std::time::Duration;
+
+#[tokio::test]
+async fn oversized_datagram_does_not_crash_receiver() {
+    // Use IPv6 loopback. On WSL2 in mirrored networking mode, IPv4 `127.0.0.1`
+    // traffic is routed through the Windows host path (MTU 1500), where the
+    // oversized datagram must fragment and WSL's broken IPv4 UDP fragment
+    // reassembly drops it. `::1` is left on the native Linux `lo` interface
+    // (MTU 65536), so the datagram arrives intact on both WSL and native Linux.
+    let mut receiver =
+        UdpSocket::bind((Ipv6Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
+    // Exercise the GRO path on platforms that support it; a no-op elsewhere.
+    receiver.enable_udp_gro().ok();
+    let recv_addr = receiver.local_addr().unwrap();
+
+    // The attacker sends a datagram larger than the 4096-byte pool buffer, followed
+    // by a legitimate small one. 8 KiB exceeds the receive buffer while staying within
+    // the most restrictive platform's single-datagram UDP limit (macOS defaults to
+    // net.inet.udp.maxdgram = 9216). On a real link such a datagram reaches the socket
+    // via IP fragment reassembly.
+    let attacker = StdUdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+    attacker.send_to(&vec![0xABu8; 8000], recv_addr).unwrap();
+    attacker.send_to(b"hello", recv_addr).unwrap();
+
+    let mut pool = PacketBufPool::<4096>::new(16);
+    // On platforms without a custom recv_many_from (the generic path) this type is
+    // `()`, so the binding has unit value; it is a reusable buffer elsewhere.
+    #[allow(clippy::let_unit_value)]
+    let mut recv_buf = <UdpSocket as UdpRecv>::RecvManyBuf::default();
+    let mut packets: Vec<(Packet, SocketAddr)> = Vec::new();
+
+    // The receiver must survive the oversized datagram (no panic) and keep working,
+    // proven by the legitimate "hello" still being delivered. A panic or a hang both
+    // fail the test - the latter via the timeout.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !packets.iter().any(|(buf, _)| &buf[..] == b"hello") {
+            receiver
+                .recv_many_from(&mut recv_buf, &mut pool, &mut packets)
+                .await
+                .unwrap();
+        }
+    })
+    .await
+    .expect("receiver must survive an oversized datagram and still deliver a valid one");
+}


### PR DESCRIPTION
A single UDP datagram larger than 4096 bytes panics GotaTun's Linux receive task (`gotatun/src/udp/socket/linux.rs`): the GRO `recvmmsg` path copies the datagram into a 4096-byte buffer without a bounds check and indexes past the end. No key, peer, or handshake is required - the panic happens during the raw `recvmmsg` copy, before any WireGuard parsing. The result is a remote, unauthenticated denial of service.

## Steps to reproduce

Build and run a GotaTun device (needs root for TUN; `/dev/net/tun` must exist):

```bash
# from repo root
cargo build -p gotatun-cli
sudo ./target/debug/gotatun wgpoc --foreground --disable-drop-privileges
```

Pin a known listen port with the standard `wg` tool (it talks to gotatun's UAPI socket at `/var/run/wireguard/wgpoc.sock`):

```bash
wg genkey | sudo tee /tmp/wgpriv >/dev/null
sudo wg set wgpoc listen-port 51820 private-key /tmp/wgpriv
sudo wg show wgpoc                  # confirms: listening port: 51820
```

Send one oversized datagram (the only requirement is a datagram >4096 bytes):

```bash
head -c 10000 /dev/zero | nc -u -w1 127.0.0.1 51820
```

## Expected result

The receiver panics:

```
thread 'tokio-rt-worker' panicked at gotatun/src/udp/socket/linux.rs:235:32:
range end index 10000 out of range for slice of length 4096
```

The process stays alive but the IPv4 receive task is dead; incoming traffic piles up undrained - check with `sudo ss -ulnp 'sport = :51820'` (Recv-Q grows). A process-liveness monitor won't notice the tunnel has stopped receiving.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/145)
<!-- Reviewable:end -->
