### PR TITLE
Enlarge replay window to 8192 bits to match WireGuard reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `noise::TimerParams` for tuning WireGuard timers. This is useful for obfuscation, but note
   that tweaking timers will cause the tunnel to deviate from the WireGuard spec.
 
+### Changed
+- Enlarge the anti-replay sliding window from 1024 to 8192 packets, matching the
+  Linux kernel and wireguard-go. Tolerates more packet reordering before dropping
+  legitimate packets. Costs ~7 KiB more memory per peer.
+
 ### Fixed
 - Add missing jitter for handshakes initiated due to not receiving any packets.
 - Passive keepalives were triggered by received keepalives, not just non-empty data packets. This

--- a/gotatun/src/noise/session.rs
+++ b/gotatun/src/noise/session.rs
@@ -21,6 +21,13 @@ use parking_lot::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use zerocopy::FromBytes;
 
+/// The maximum number of transport data messages that may be sent or received under a single
+/// session key, per section 6.2 of the [whitepaper](https://www.wireguard.com/papers/wireguard.pdf)
+/// (`Reject-After-Messages = 2^64 - 2^13 - 1`).
+/// Refusing to use a counter at or beyond this value guarantees the 64-bit AEAD nonce can never
+/// wrap and reuse a nonce with the same key.
+pub(super) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1 << 13);
+
 pub struct Session {
     pub(crate) receiving_index: Index,
     sending_index: u32,
@@ -42,17 +49,11 @@ impl std::fmt::Debug for Session {
 
 // Receiving buffer constants
 const WORD_SIZE: u64 = 64;
-const N_WORDS: u64 = 16; // Suffice to reorder 64*16 = 1024 packets; can be increased at will
+// 64*128 = 8192, matching the WireGuard replay window in both the Linux kernel and wireguard-go
+const N_WORDS: u64 = 128;
 const N_BITS: u64 = WORD_SIZE * N_WORDS;
 
-/// The maximum number of transport data messages that may be sent or received under a single
-/// session key, per section 6.2 of the [whitepaper](https://www.wireguard.com/papers/wireguard.pdf)
-/// (`Reject-After-Messages = 2^64 - 2^13 - 1`).
-/// Refusing to use a counter at or beyond this value guarantees the 64-bit AEAD nonce can never
-/// wrap and reuse a nonce with the same key.
-pub(super) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1 << 13);
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 struct ReceivingKeyCounterValidator {
     /// In order to avoid replays while allowing for some reordering of the packets, we keep a
     /// bitmap of received packets, and the value of the highest counter
@@ -60,6 +61,17 @@ struct ReceivingKeyCounterValidator {
     /// Used to estimate packet loss
     receive_cnt: u64,
     bitmap: [u64; N_WORDS as usize],
+}
+
+impl Default for ReceivingKeyCounterValidator {
+    fn default() -> Self {
+        // `derive(Default)` only covers arrays up to length 32, so implement it by hand.
+        Self {
+            next: 0,
+            receive_cnt: 0,
+            bitmap: [0u64; N_WORDS as usize],
+        }
+    }
 }
 
 impl ReceivingKeyCounterValidator {


### PR DESCRIPTION
TLDR: This change is not in any way critical. It allows GotaTun to handle packet network reordering in more extreme (maybe only theoretical?) conditions. The cost is ~7 KiB  memory usage per peer. I propose this change to align with the Linux Kernel WireGuard implementation and wireguard-go. But if we think this is pointless, or we can actually measure performance losses because of this, then we can also stay on 1024, but with an improved comment on why we choose this lower value.

#### Longer explanation

The receive-side anti-replay sliding window was 1024 bits, inherited from boringtun. The Linux kernel and wireguard-go both use 8192. A smaller window is not a security weakness, it just tolerates less packet reordering before dropping legitimate packets as false replays.

All three implementations validate the counter in network-arrival order, so the window only ever needs to absorb reordering from the network, which for a single flow is small. GotaTun is serial throughout. The kernel and wireguard-go decrypt in parallel across cores but re-serialize per peer before the replay check (kernel counter_validate in wg_packet_rx_poll draining the in-order rx_queue; wireguard-go ValidateCounter in RoutineSequentialReceiver), so their parallelism never feeds reordered counters to the window either. 8192 is just a conservative margin the kernel chose and wireguard-go copied; GotaTun's 1024 was already adequate. Matching the reference is cheap parity, not a fix for a real reorder gap.

Bump N_WORDS 16 -> 128. `Default` is now hand-written since derive does not cover `[u64; 128]`.

The wider bitmap costs 896 extra bytes per session (128 -> 1024 bytes). Sessions are held in a fixed inline [Option<Session>; 8] array per peer, so the cost is ~7 KiB (896 * 8) per peer regardless of how many session slots are active. Negligible except at very large peer counts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/146)
<!-- Reviewable:end -->
