### PR TITLE
Remove unnecessary `unsafe impl Send for RecvManyBuf`

### DIFF
--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -127,10 +127,6 @@ mod gro {
         pub(crate) gro_bufs: Box<[BytesMut; MAX_PACKET_COUNT]>,
     }
 
-    // SAFETY: MultiHeaders contains pointers, but we only ever mutate data in
-    // [Self::recv_many_from]. This should be fine.
-    unsafe impl Send for RecvManyBuf {}
-
     impl Default for RecvManyBuf {
         fn default() -> Self {
             let mut gro_buf = BytesMut::zeroed(MAX_PACKET_COUNT * MAX_GRO_SIZE);


### PR DESCRIPTION
The struct's only field is `Box<[BytesMut; N]>`, which is unconditionally `Send`, so the compiler auto-derives `Send`. The manual impl is dead code left behind by an earlier refactor that moved the `MultiHeaders` field (the actual !Send type the impl and its stale safety comment referred to) into the `recv_many_from` method body. Removing the impl restores compiler-checked soundness: a future `!Send` field now fails to compile instead of being silently masked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/147)
<!-- Reviewable:end -->
