### PR TITLE
Add configurable timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `noise::TimerParams` for tuning WireGuard timers. This is useful for obfuscation, but note
+  that tweaking timers will cause the tunnel to deviate from the WireGuard spec.
+
 ### Fixed
 - Add missing jitter for handshakes initiated due to not receiving any packets.
 - Passive keepalives were triggered by received keepalives, not just non-empty data packets. This

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -191,6 +191,7 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
                     keepalive: p.tunnel.persistent_keepalive(),
                     #[cfg(feature = "daita")]
                     daita_settings: daita,
+                    danger_timer_params: Some(p.tunnel.timer_params().clone()),
                 },
                 stats,
             });

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -367,7 +367,7 @@ impl<T: DeviceTransports> DeviceState<T> {
             .expect("Setting private key creates rate limiter")
             .clone();
 
-        let tunn = Tunn::new(
+        let mut tunn = Tunn::new(
             device_key_pair.0.clone(),
             peer_builder.public_key,
             peer_builder.preshared_key,
@@ -375,6 +375,10 @@ impl<T: DeviceTransports> DeviceState<T> {
             self.index_table.clone(),
             rate_limiter,
         );
+
+        if let Some(timer_params) = peer_builder.danger_timer_params {
+            tunn.dangerously_set_timer_params(timer_params);
+        }
 
         PeerState::new(
             tunn,

--- a/gotatun/src/device/peer.rs
+++ b/gotatun/src/device/peer.rs
@@ -16,6 +16,7 @@ use x25519_dalek::PublicKey;
 
 #[cfg(feature = "daita")]
 use crate::device::daita::DaitaSettings;
+use crate::noise::TimerParams;
 
 /// Peer data. Used to construct and update peers in a [`Device`](crate::device::Device).
 #[derive(Clone, Debug)]
@@ -40,6 +41,11 @@ pub struct Peer {
     /// DAITA settings for this peer, if the DAITA feature is enabled.
     #[cfg(feature = "daita")]
     pub daita_settings: Option<DaitaSettings>,
+
+    /// Override of the WireGuard timers for this peer. Use defaults if unspecified.
+    ///
+    /// See [TimerParams].
+    pub danger_timer_params: Option<TimerParams>,
 }
 
 impl Peer {
@@ -55,6 +61,7 @@ impl Peer {
             keepalive: None,
             #[cfg(feature = "daita")]
             daita_settings: None,
+            danger_timer_params: None,
         }
     }
 
@@ -86,6 +93,12 @@ impl Peer {
     #[cfg(feature = "daita")]
     pub fn with_daita(mut self, daita_settings: DaitaSettings) -> Self {
         self.daita_settings = Some(daita_settings);
+        self
+    }
+
+    /// Override the WireGuard timer deadlines for this peer.
+    pub fn dangerously_with_timer_params(mut self, timer_params: TimerParams) -> Self {
+        self.danger_timer_params = Some(timer_params);
         self
     }
 }

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -654,6 +654,7 @@ async fn on_api_set(
                     },
                     #[cfg(feature = "daita")]
                     daita_settings: peer.daita_settings().cloned(),
+                    danger_timer_params: Some(peer.tunnel.timer_params().clone()),
                 }
             }
         };

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -24,14 +24,16 @@ pub mod rate_limiter;
 mod session;
 mod timers;
 
-use rand::{Rng, RngCore, SeedableRng, rngs::StdRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use zerocopy::IntoBytes;
 
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::Handshake;
 use crate::noise::index_table::IndexTable;
 use crate::noise::rate_limiter::RateLimiter;
-use crate::noise::timers::{MAX_JITTER, TimerName, Timers};
+use crate::noise::timers::{TimerName, Timers};
+
+pub use crate::noise::timers::TimerParams;
 use crate::packet::{Packet, WgCookieReply, WgData, WgHandshakeInit, WgHandshakeResp, WgKind};
 use crate::tun::MtuWatcher;
 use crate::x25519;
@@ -406,21 +408,16 @@ impl<R: RngCore + Send> Tunn<R> {
             self.timer_tick(TimerName::TimeLastHandshakeStarted);
         }
         self.timer_tick(TimerName::TimeLastPacketSent);
-        self.update_handshake_jitter();
+        self.update_rekey_timeout();
 
         self.tx_bytes += packet.as_bytes().len();
 
         Some(packet)
     }
 
-    /// Update jitter to apply to the handshake initiation retry timer.
-    fn update_handshake_jitter(&mut self) {
-        self.timers.handshake_jitter = self.next_jitter();
-    }
-
-    /// Calculate a jitter for the handshake initiation retry timer.
-    fn next_jitter(&mut self) -> Duration {
-        self.jitter_rng.random_range(Duration::ZERO..=MAX_JITTER)
+    /// Sample a new deadline for the handshake initiation retry timer.
+    fn update_rekey_timeout(&mut self) {
+        self.timers.rekey_timeout = self.sample_timer(|p| &p.rekey_timeout);
     }
 
     /// Encapsulate and return all queued packets.
@@ -996,14 +993,17 @@ mod tests {
             FixedRng(200),
         );
 
-        let expected_jitter = my_tun.next_jitter();
+        // The FixedRng makes this draw identical to the one made when the handshake is sent.
+        let expected_deadline = my_tun.sample_timer(|p| &p.rekey_timeout);
+        assert!(expected_deadline >= REKEY_TIMEOUT);
+        assert!(expected_deadline <= REKEY_TIMEOUT + MAX_JITTER);
 
-        // Trigger the initial handshake via handle_outgoing_packet, which sets jitter.
+        // Trigger the initial handshake via handle_outgoing_packet, which samples the deadline.
         let packet = create_ipv4_udp_packet();
         let _ = my_tun.handle_outgoing_packet(packet.into_bytes(), None);
 
         // Just before REKEY_TIMEOUT + jitter: no retry yet.
-        MockClock::advance(REKEY_TIMEOUT + expected_jitter - Duration::from_millis(1));
+        MockClock::advance(expected_deadline - Duration::from_millis(1));
         assert!(
             matches!(my_tun.update_timers(), Ok(None)),
             "retry should not fire before REKEY_TIMEOUT + jitter"
@@ -1015,6 +1015,71 @@ mod tests {
             matches!(my_tun.update_timers(), Ok(Some(WgKind::HandshakeInit(..)))),
             "retry should fire at REKEY_TIMEOUT + jitter"
         );
+    }
+
+    /// Verify that custom [`TimerParams`] move the rekey-after-time and passive keepalive
+    /// deadlines.
+    #[test]
+    #[cfg(feature = "mock_instant")]
+    fn custom_timer_params_applied() {
+        const REKEY_AFTER: Duration = Duration::from_secs(100);
+        const KEEPALIVE: Duration = Duration::from_secs(8);
+        // Far enough away to never interfere with the deadlines under test.
+        const NEW_HANDSHAKE: Duration = Duration::from_secs(1000);
+        const MS: Duration = Duration::from_millis(1);
+
+        MockClock::set_time(Duration::ZERO);
+
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        my_tun.dangerously_set_timer_params(TimerParams {
+            keepalive_timeout: KEEPALIVE..=KEEPALIVE,
+            new_handshake_timeout: NEW_HANDSHAKE..=NEW_HANDSHAKE,
+            rekey_after_time: REKEY_AFTER..=REKEY_AFTER,
+            ..TimerParams::default()
+        });
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, init);
+        let keepalive = parse_handshake_resp(&mut my_tun, resp);
+        parse_keepalive(&mut their_tun, keepalive);
+
+        // Receive a data packet at t = 1 s without answering. The passive keepalive
+        // should fire KEEPALIVE (rather than the default 10 s) after the data arrived.
+        MockClock::advance(Duration::from_secs(1));
+        assert!(matches!(my_tun.update_timers(), Ok(None)));
+
+        let sent_packet_buf = create_ipv4_udp_packet();
+        let data = their_tun
+            .handle_outgoing_packet(sent_packet_buf.into_bytes(), None)
+            .expect("expected encapsulated packet");
+        let _ = my_tun.handle_incoming_packet(data);
+
+        MockClock::advance(KEEPALIVE - MS);
+        assert!(
+            matches!(my_tun.update_timers(), Ok(None)),
+            "keepalive should not fire before the custom timeout"
+        );
+        MockClock::advance(MS);
+        assert!(
+            matches!(my_tun.update_timers(), Ok(Some(WgKind::Data(p))) if p.is_keepalive()),
+            "keepalive should fire at the custom timeout"
+        );
+
+        // Send a data packet on the aging session (t = 1 s + KEEPALIVE). As the initiator,
+        // we should start a new handshake REKEY_AFTER (rather than the default 120 s) after
+        // session establishment (t = 0).
+        let sent_packet_buf = create_ipv4_udp_packet();
+        let _ = my_tun
+            .handle_outgoing_packet(sent_packet_buf.into_bytes(), None)
+            .expect("expected encapsulated packet");
+
+        MockClock::advance(REKEY_AFTER - KEEPALIVE - Duration::from_secs(1) - MS);
+        assert!(
+            matches!(my_tun.update_timers(), Ok(None)),
+            "rekey should not fire before the custom rekey-after-time"
+        );
+        MockClock::advance(MS);
+        update_timer_results_in_handshake(&mut my_tun);
     }
 
     /// Verify that a received keepalive is not answered with a passive keepalive.

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -14,12 +14,13 @@ use super::errors::WireGuardError;
 use crate::noise::Tunn;
 use crate::packet::WgKind;
 
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, RangeInclusive};
 use std::time::Duration;
 
 use bytes::BytesMut;
 #[cfg(feature = "mock_instant")]
 use mock_instant::thread_local::Instant;
+use rand::Rng;
 
 #[cfg(not(feature = "mock_instant"))]
 use crate::sleepyinstant::Instant;
@@ -59,6 +60,50 @@ pub enum TimerName {
 
 use self::TimerName::*;
 
+/// Tuning of WireGuard timers.
+///
+/// Each timeout is sampled uniformly from its range when the corresponding timer is armed.
+///
+/// The defaults match the timings from the WireGuard paper.
+///
+/// # Note
+///
+/// Tweaking these values will cause your tunnel to deviate from the WireGuard spec. Use with
+/// caution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimerParams {
+    /// How long to wait, after receiving a data packet without sending anything back, before
+    /// sending a passive keepalive.
+    ///
+    /// Sampled when the passive keepalive timer is armed.
+    pub keepalive_timeout: RangeInclusive<Duration>,
+    /// How long to wait, after sending a data packet without hearing anything back, before
+    /// initiating a new handshake.
+    ///
+    /// Sampled when the new-handshake timer is armed.
+    pub new_handshake_timeout: RangeInclusive<Duration>,
+    /// How long to wait before retransmitting an unanswered handshake initiation.
+    ///
+    /// Sampled each time a handshake initiation is sent.
+    pub rekey_timeout: RangeInclusive<Duration>,
+    /// Session age after which the initiator initiates a new handshake when sending data.
+    ///
+    /// Sampled when a session is established.
+    pub rekey_after_time: RangeInclusive<Duration>,
+}
+
+impl Default for TimerParams {
+    fn default() -> Self {
+        TimerParams {
+            keepalive_timeout: KEEPALIVE_TIMEOUT..=KEEPALIVE_TIMEOUT,
+            new_handshake_timeout: (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                ..=(KEEPALIVE_TIMEOUT + REKEY_TIMEOUT + MAX_JITTER),
+            rekey_timeout: REKEY_TIMEOUT..=(REKEY_TIMEOUT + MAX_JITTER),
+            rekey_after_time: REKEY_AFTER_TIME..=REKEY_AFTER_TIME,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Timers {
     /// Is the owner of the timer the initiator or the responder for the last handshake?
@@ -68,22 +113,30 @@ pub struct Timers {
     timers: [Duration; TimerName::Top as usize],
     pub(super) session_timers: [Duration; super::N_SESSIONS],
     /// Time the first data packet was received without us sending anything back, if any.
-    /// A passive keepalive is due `KEEPALIVE_TIMEOUT` after this time.
+    /// A passive keepalive is due `keepalive_timeout` after this time.
     want_keepalive: Option<Duration>,
     /// First data packet sent without hearing back
     want_handshake: Option<Duration>,
     persistent_keepalive: Option<Duration>,
-    /// Jitter added to the current [`REKEY_TIMEOUT`] interval.
-    /// This should be randomized on each handshake initiation.
-    pub(super) handshake_jitter: Duration,
-    /// Jitter added to the new-handshake timeout (`KEEPALIVE_TIMEOUT + REKEY_TIMEOUT`).
-    /// This should be randomized each time the new-handshake timer is armed.
-    new_handshake_jitter: Duration,
+    /// Timer deadline ranges that the sampled deadlines below are drawn from.
+    pub(super) params: TimerParams,
+    /// Current passive keepalive deadline.
+    /// Sampled from [`TimerParams::keepalive_timeout`] when `want_keepalive` is armed.
+    keepalive_timeout: Duration,
+    /// Current new-handshake-after-silence deadline.
+    /// Sampled from [`TimerParams::new_handshake_timeout`] when `want_handshake` is armed.
+    new_handshake_timeout: Duration,
+    /// Current handshake retransmit deadline (including jitter).
+    /// Sampled from [`TimerParams::rekey_timeout`] on each handshake initiation.
+    pub(super) rekey_timeout: Duration,
+    /// Current rekey-after-time deadline.
+    /// Sampled from [`TimerParams::rekey_after_time`] when a session is established.
+    rekey_after_time: Duration,
 }
 
 impl Timers {
     pub(super) fn new(persistent_keepalive: Option<u16>) -> Timers {
-        Timers {
+        let mut timers = Timers {
             is_initiator: false,
             time_started: Instant::now(),
             timers: Default::default(),
@@ -93,9 +146,25 @@ impl Timers {
             persistent_keepalive: persistent_keepalive
                 .filter(|&s| s > 0)
                 .map(|s| Duration::from_secs(s.into())),
-            handshake_jitter: Duration::ZERO,
-            new_handshake_jitter: Duration::ZERO,
-        }
+            params: TimerParams::default(),
+            keepalive_timeout: Duration::ZERO,
+            new_handshake_timeout: Duration::ZERO,
+            rekey_timeout: Duration::ZERO,
+            rekey_after_time: Duration::ZERO,
+        };
+        timers.dangerously_set_params(TimerParams::default());
+        timers
+    }
+
+    /// Replace the timer params, resetting all sampled deadlines.
+    ///
+    /// See [TimerParams].
+    pub(super) fn dangerously_set_params(&mut self, params: TimerParams) {
+        self.keepalive_timeout = *params.keepalive_timeout.start();
+        self.new_handshake_timeout = *params.new_handshake_timeout.start();
+        self.rekey_timeout = *params.rekey_timeout.start();
+        self.rekey_after_time = *params.rekey_after_time.end();
+        self.params = params;
     }
 
     fn is_initiator(&self) -> bool {
@@ -111,8 +180,7 @@ impl Timers {
         }
         self.want_handshake = None;
         self.want_keepalive = None;
-        self.handshake_jitter = Duration::ZERO;
-        self.new_handshake_jitter = Duration::ZERO;
+        self.dangerously_set_params(self.params.clone());
     }
 
     /// Compute the time elapsed since [`Self::time_started`] based on [`Instant::now`].
@@ -153,6 +221,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
             }
             TimeLastDataPacketReceived => {
                 if self.timers.want_keepalive.is_none() {
+                    self.timers.keepalive_timeout = self.sample_timer(|p| &p.keepalive_timeout);
                     self.timers.want_keepalive = Some(time);
                 }
                 // The Linux kernel schedules an extra keepalive here if one is already queued:
@@ -168,7 +237,8 @@ impl<R: rand::RngCore + Send> Tunn<R> {
             }
             TimeLastDataPacketSent => {
                 if self.timers.want_handshake.is_none() {
-                    self.timers.new_handshake_jitter = self.next_jitter();
+                    self.timers.new_handshake_timeout =
+                        self.sample_timer(|p| &p.new_handshake_timeout);
                     self.timers.want_handshake = Some(time);
                 }
             }
@@ -176,6 +246,20 @@ impl<R: rand::RngCore + Send> Tunn<R> {
         }
 
         self.timers[timer_name] = time;
+    }
+
+    /// Sample a deadline uniformly from one of the [`TimerParams`] ranges.
+    pub(super) fn sample_timer(
+        &mut self,
+        range: impl FnOnce(&TimerParams) -> &RangeInclusive<Duration>,
+    ) -> Duration {
+        let range = range(&self.timers.params).clone();
+        if range.start() >= range.end() {
+            // Avoid consuming randomness for fixed deadlines.
+            *range.start()
+        } else {
+            self.jitter_rng.random_range(range)
+        }
     }
 
     pub(super) fn timer_tick_session_established(
@@ -187,6 +271,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
         self.timers.session_timers[session_idx % crate::noise::N_SESSIONS] =
             self.timers[TimeCurrent];
         self.timers.is_initiator = is_initiator;
+        self.timers.rekey_after_time = self.sample_timer(|p| &p.rekey_after_time);
     }
 
     // We don't really clear the timers, but we set them to the current time to
@@ -276,12 +361,11 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                     return Err(WireGuardError::ConnectionExpired);
                 }
 
-                if time_init_sent.elapsed() >= REKEY_TIMEOUT + self.timers.handshake_jitter {
+                if time_init_sent.elapsed() >= self.timers.rekey_timeout {
                     // We avoid using `time` here, because it can be earlier than `time_init_sent`.
                     // Once `checked_duration_since` is stable we can use that.
-                    // A handshake initiation is retried after REKEY_TIMEOUT + jitter ms,
-                    // if a response has not been received, where jitter is some random
-                    // value between 0 and 333 ms.
+                    // A handshake initiation is retried after the sampled rekey timeout,
+                    // by default REKEY_TIMEOUT plus some random jitter between 0 and 333 ms.
                     log::debug!("HANDSHAKE(REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
@@ -293,7 +377,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                     // responder of the handshake, it does not re-initiate a new handshake
                     // after REKEY_AFTER_TIME ms like the original initiator does.
                     if session_established < data_packet_sent
-                        && now - session_established >= REKEY_AFTER_TIME
+                        && now - session_established >= self.timers.rekey_after_time
                     {
                         log::trace!("HANDSHAKE(REKEY_AFTER_TIME (on send))");
                         handshake_initiation_required = true;
@@ -317,11 +401,10 @@ impl<R: rand::RngCore + Send> Tunn<R> {
                 }
 
                 // If we have sent a data packet to a given peer but have not received a
-                // packet after from that peer for `(KEEPALIVE + REKEY_TIMEOUT)`,
-                // we initiate a new handshake.
+                // packet after from that peer for the sampled new-handshake timeout
+                // (`KEEPALIVE + REKEY_TIMEOUT` by default), we initiate a new handshake.
                 if let Some(since) = self.timers.want_handshake
-                    && now.saturating_sub(since)
-                        >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT + self.timers.new_handshake_jitter
+                    && now.saturating_sub(since) >= self.timers.new_handshake_timeout
                 {
                     log::trace!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
@@ -330,9 +413,10 @@ impl<R: rand::RngCore + Send> Tunn<R> {
 
                 if !handshake_initiation_required {
                     // If a data packet has been received from a given peer, but we have not sent
-                    // one back to the given peer in KEEPALIVE ms, we send an empty packet.
+                    // anything back within the sampled keepalive timeout (KEEPALIVE ms by
+                    // default), we send an empty packet.
                     if let Some(since) = self.timers.want_keepalive
-                        && now.saturating_sub(since) >= KEEPALIVE_TIMEOUT
+                        && now.saturating_sub(since) >= self.timers.keepalive_timeout
                     {
                         log::trace!("KEEPALIVE(KEEPALIVE_TIMEOUT)");
                         keepalive_required = true;
@@ -387,6 +471,18 @@ impl<R: rand::RngCore + Send> Tunn<R> {
             .persistent_keepalive
             .map(|keepalive| keepalive.as_secs() as u16)
             .filter(|&keepalive| keepalive > 0)
+    }
+
+    /// Get the timer params for this tunnel.
+    pub fn timer_params(&self) -> &TimerParams {
+        &self.timers.params
+    }
+
+    /// Set the timer params for this tunnel, controlling when WireGuard timers fire.
+    ///
+    /// See [TimerParams].
+    pub fn dangerously_set_timer_params(&mut self, params: TimerParams) {
+        self.timers.dangerously_set_params(params);
     }
 
     /// Set the persistent keepalive interval in seconds.


### PR DESCRIPTION
Builds on #144. This makes it possible to tweak some timer values, useful for some kinds of obfuscation.

It allows some timers to be tweaked, and these are uniformly at random sampled from the specified ranges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/148)
<!-- Reviewable:end -->
