### PR TITLE
Make `modify_peer` and `update_peer` not invalidate existing sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The passive keepalive timer was relative to the *last sent packet*. This meant that an idle tunnel
   receiving a packet would instantly send a keepalive (instead of waiting for `KEEPALIVE-TIMEOUT`).
 - Do not send persistent keepalives if tunnel is active.
+- Propagate preshared-key (PSK) changes to the tunnel. Changing a peer's preshared key via
+  `DeviceWrite::modify_peer`/`update_peer` updated the stored config but not the noise state, so
+  handshakes kept using the old key. The new key now takes effect on the next handshake without
+  tearing down the live session, matching the Linux kernel and wireguard-go.
 
 ### Security
 - Enforce the `Reject-After-Messages` limit on the transport data counter, so a

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -232,22 +232,41 @@ async fn reverse_path_rejects_source_owned_by_another_peer() {
     );
 }
 
-#[derive(Clone, Copy)]
-enum PeerUpdateApi {
-    Modify,
-    Update,
-}
-
+/// Ensures setting a peer's preshared key via Device::modify_peer propagates into its noise state
 #[tokio::test]
 #[test_log::test]
-async fn modify_peer_updates_live_preshared_key() {
-    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Modify).await;
+async fn modify_peer_preshared_key_reaches_tunnel() {
+    assert_peer_psk_update_reaches_tunnel(async |device: &mut mock::MockDevice, preshared_key| {
+        let peer = get_first_and_only_peer(device).await;
+        let updated = device
+            .device
+            .modify_peer(&peer.public_key, |peer_mut| {
+                peer_mut.set_preshared_key(Some(preshared_key));
+            })
+            .await
+            .expect("modify_peer should succeed");
+        assert!(updated, "peer update should affect an existing peer");
+        advance_mock_clock();
+    })
+    .await;
 }
 
+/// Ensures setting a peer's preshared key via Device::update_peer propagates into its noise state
 #[tokio::test]
 #[test_log::test]
-async fn update_peer_updates_live_preshared_key() {
-    assert_peer_psk_update_changes_live_handshake(PeerUpdateApi::Update).await;
+async fn update_peer_preshared_key_reaches_tunnel() {
+    assert_peer_psk_update_reaches_tunnel(async |device: &mut mock::MockDevice, preshared_key| {
+        let mut peer = get_first_and_only_peer(device).await;
+        peer.preshared_key = Some(preshared_key);
+        let updated = device
+            .device
+            .update_peer(peer)
+            .await
+            .expect("update_peer should succeed");
+        assert!(updated, "peer update should affect an existing peer");
+        advance_mock_clock();
+    })
+    .await;
 }
 
 /// The number of packets we send through the tunnel
@@ -255,53 +274,50 @@ fn packet_count() -> usize {
     mock::packets_of_every_size().len()
 }
 
-async fn assert_peer_psk_update_changes_live_handshake(api: PeerUpdateApi) {
-    let (mut alice, mut bob, _eve) = mock::device_pair().await;
+/// Setting a peer's preshared key must propagate into its noise state, and must
+/// not tear down a live session. `set_preshared_key` applies the change through
+/// one of the device's configuration APIs.
+async fn assert_peer_psk_update_reaches_tunnel(
+    set_preshared_key: impl AsyncFn(&mut mock::MockDevice, [u8; 32]),
+) {
     let packet = mock::packet(b"Hello!");
     let preshared_key = [0xA5; 32];
 
-    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
-    send_and_expect_blocked(&alice, &mut bob, &packet).await;
+    // One side changes its PSK: the peers disagree and the handshake fails.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        set_preshared_key(&mut alice, preshared_key).await;
+        send_and_expect_blocked(&alice, &mut bob, &packet).await;
+    }
 
-    apply_peer_psk_update(&mut bob, api, Some(preshared_key)).await;
-    // Reset Alice's failed in-flight handshake so the next packet starts a fresh exchange.
-    apply_peer_psk_update(&mut alice, api, Some([0x5A; 32])).await;
-    apply_peer_psk_update(&mut alice, api, Some(preshared_key)).await;
+    // Both sides set the same PSK: traffic flows.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        set_preshared_key(&mut alice, preshared_key).await;
+        set_preshared_key(&mut bob, preshared_key).await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+    }
 
-    send_and_expect_delivery(&alice, &mut bob, &packet).await;
+    // Updating an established peer keeps the live session working.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+        set_preshared_key(&mut alice, preshared_key).await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+    }
 }
 
-async fn apply_peer_psk_update(
-    device: &mut mock::MockDevice,
-    api: PeerUpdateApi,
-    preshared_key: Option<[u8; 32]>,
-) {
-    let mut peers = device.device.peers().await;
-    assert_eq!(peers.len(), 1, "expected exactly one peer");
+/// Return the device's single configured peer, asserting there is exactly one.
+async fn get_first_and_only_peer(device: &mock::MockDevice) -> crate::device::Peer {
+    let peers = device.device.peers().await;
+    let [stats] = <[_; 1]>::try_from(peers).expect("expected exactly one peer");
+    stats.peer
+}
 
-    let mut peer = peers.pop().expect("missing peer").peer;
-    let updated = match api {
-        PeerUpdateApi::Modify => device
-            .device
-            .modify_peer(&peer.public_key, |peer_mut| {
-                peer_mut.set_preshared_key(preshared_key);
-            })
-            .await
-            .expect("modify_peer should succeed"),
-        PeerUpdateApi::Update => {
-            peer.preshared_key = preshared_key;
-            device
-                .device
-                .update_peer(peer)
-                .await
-                .expect("update_peer should succeed")
-        }
-    };
-
+/// Advance the mock clock so consecutive handshakes get distinct timestamps.
+fn advance_mock_clock() {
     #[cfg(feature = "mock_instant")]
     mock_instant::thread_local::MockClock::advance(Duration::from_micros(1));
-
-    assert!(updated, "peer update should affect an existing peer");
 }
 
 async fn send_and_expect_blocked(

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -506,12 +506,11 @@ impl Handshake {
         self.previous = HandshakeState::None;
     }
 
-    /// Update the preshared key and invalidate handshake state derived from the previous value.
+    /// Store the preshared key used by future handshakes.
+    ///
+    /// Any in-flight handshake and established sessions are deliberately left untouched.
     pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.params.set_preshared_key(preshared_key);
-        // Invalidate in-flight handshakes
-        self.state = HandshakeState::None;
-        self.previous = HandshakeState::None;
     }
 
     /// Get the preshared key

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -165,13 +165,15 @@ impl<R: RngCore + Send> Tunn<R> {
         }
     }
 
-    /// Update the preshared key and clear existing sessions.
+    /// Update the preshared key used for future handshakes.
+    ///
+    /// The new key is only mixed in by subsequent handshakes. The current
+    /// session therefore keeps working until it is rekeyed, so changing
+    /// the key does not interrupt traffic.
+    // Not invalidating current sessions matches the Linux kernel, which update
+    // the key in place and never tear down the session on a configuration change.
     pub fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
         self.handshake.set_preshared_key(preshared_key);
-        // Established sessions are keyed from the previous PSK and must not remain usable.
-        for s in &mut self.sessions {
-            *s = None;
-        }
     }
 
     /// Get the current preshared key.
@@ -614,12 +616,15 @@ mod tests {
 
     fn create_two_tuns_and_handshake() -> (Tunn, Tunn) {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        let init = create_handshake_init(&mut my_tun);
-        let resp = create_handshake_response(&mut their_tun, init);
-        let keepalive = parse_handshake_resp(&mut my_tun, resp);
-        parse_keepalive(&mut their_tun, keepalive);
-
+        complete_handshake(&mut my_tun, &mut their_tun);
         (my_tun, their_tun)
+    }
+
+    fn complete_handshake(my_tun: &mut Tunn, their_tun: &mut Tunn) {
+        let init = create_handshake_init(my_tun);
+        let resp = create_handshake_response(their_tun, init);
+        let keepalive = parse_handshake_resp(my_tun, resp);
+        parse_keepalive(their_tun, keepalive);
     }
 
     fn create_ipv4_udp_packet() -> Packet<Ipv4> {
@@ -831,64 +836,50 @@ mod tests {
     #[test]
     fn one_ip_packet() {
         let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
-
-        let sent_packet_buf = create_ipv4_udp_packet();
-
-        let data = my_tun
-            .handle_outgoing_packet(sent_packet_buf.clone().into_bytes(), None)
-            .unwrap();
-
-        assert!(matches!(data, WgKind::Data(..)));
-
-        let data = their_tun.handle_incoming_packet(data);
-        let recv_packet_buf = if let TunnResult::WriteToTunnel(recv) = data {
-            recv
-        } else {
-            unreachable!("expected WritetoTunnelV4");
-        };
-        assert_eq!(sent_packet_buf.as_bytes(), recv_packet_buf.as_bytes());
+        assert_packet_roundtrip(&mut my_tun, &mut their_tun);
     }
 
+    /// Changing the preshared key must not tear down the established session: the
+    /// PSK is not part of its transport keys, so traffic keeps flowing even
+    /// though `their_tun` never learned the new key.
     #[test]
-    fn set_preshared_key_invalidates_existing_sessions() {
-        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake();
-
-        assert!(my_tun.time_since_last_handshake().is_some());
-
+    fn set_preshared_key_keeps_existing_session() {
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
         my_tun.set_preshared_key(Some([7; 32]));
-
-        assert!(my_tun.time_since_last_handshake().is_none());
-        assert!(matches!(
-            my_tun.handle_outgoing_packet(create_ipv4_udp_packet().into_bytes(), None),
-            Some(WgKind::HandshakeInit(..))
-        ));
+        assert_packet_roundtrip(&mut my_tun, &mut their_tun);
     }
 
+    /// Send one IP packet over the established session and assert it round-trips.
+    fn assert_packet_roundtrip(from: &mut Tunn, to: &mut Tunn) {
+        let sent = create_ipv4_udp_packet();
+        let data = from
+            .handle_outgoing_packet(sent.clone().into_bytes(), None)
+            .expect("session should encrypt the packet");
+        let TunnResult::WriteToTunnel(received) = to.handle_incoming_packet(data) else {
+            panic!("session should decrypt the packet");
+        };
+        assert_eq!(sent.as_bytes(), received.as_bytes());
+    }
+
+    /// A stored preshared key is mixed into the next handshake: matching keys on
+    /// both sides complete it, a one-sided key fails to authenticate.
     #[test]
-    fn set_preshared_key_resets_handshake_replay_state() {
-        let (mut my_tun, mut their_tun) = create_two_tuns();
+    fn set_preshared_key_applies_to_next_handshake() {
         let preshared_key = [7; 32];
 
+        let (mut my_tun, mut their_tun) = create_two_tuns();
         my_tun.set_preshared_key(Some(preshared_key));
+        their_tun.set_preshared_key(Some(preshared_key));
+        complete_handshake(&mut my_tun, &mut their_tun);
 
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        my_tun.set_preshared_key(Some(preshared_key));
         let init = create_handshake_init(&mut my_tun);
         let resp = create_handshake_response(&mut their_tun, init);
         assert!(matches!(
             my_tun.handle_incoming_packet(WgKind::HandshakeResp(resp)),
             TunnResult::Err(WireGuardError::InvalidAeadTag)
         ));
-
-        their_tun.set_preshared_key(Some(preshared_key));
-        my_tun.set_preshared_key(Some([8; 32]));
-        my_tun.set_preshared_key(Some(preshared_key));
-
-        #[cfg(feature = "mock_instant")]
-        mock_instant::thread_local::MockClock::advance(Duration::from_micros(1));
-
-        let init = create_handshake_init(&mut my_tun);
-        let resp = create_handshake_response(&mut their_tun, init);
-        let keepalive = parse_handshake_resp(&mut my_tun, resp);
-        parse_keepalive(&mut their_tun, keepalive);
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -591,24 +591,6 @@ mod tests {
         handshake_resp
     }
 
-    fn parse_handshake_resp(
-        tun: &mut Tunn,
-        handshake_resp: Packet<WgHandshakeResp>,
-    ) -> Packet<WgData> {
-        let keepalive = tun.handle_incoming_packet(WgKind::HandshakeResp(handshake_resp));
-        assert!(matches!(keepalive, TunnResult::WriteToNetwork(_)));
-
-        let TunnResult::WriteToNetwork(keepalive) = keepalive else {
-            unreachable!("expected WriteToNetwork")
-        };
-
-        let WgKind::Data(keepalive) = keepalive else {
-            unreachable!("expected WgData, got {keepalive:?}");
-        };
-
-        keepalive
-    }
-
     fn parse_keepalive(tun: &mut Tunn, keepalive: Packet<WgData>) {
         let result = tun.handle_incoming_packet(WgKind::Data(keepalive));
         assert!(matches!(result, TunnResult::WriteToTunnel(p) if p.is_empty()));
@@ -621,10 +603,19 @@ mod tests {
     }
 
     fn complete_handshake(my_tun: &mut Tunn, their_tun: &mut Tunn) {
+        let result = try_handshake(my_tun, their_tun);
+        let TunnResult::WriteToNetwork(WgKind::Data(keepalive)) = result else {
+            panic!("expected a keepalive packet after the handshake, got {result:?}");
+        };
+        parse_keepalive(their_tun, keepalive);
+    }
+
+    /// Drive a handshake up to the point where the initiator processes the
+    /// response, returning that result so callers can assert success or failure.
+    fn try_handshake(my_tun: &mut Tunn, their_tun: &mut Tunn) -> TunnResult {
         let init = create_handshake_init(my_tun);
         let resp = create_handshake_response(their_tun, init);
-        let keepalive = parse_handshake_resp(my_tun, resp);
-        parse_keepalive(their_tun, keepalive);
+        my_tun.handle_incoming_packet(WgKind::HandshakeResp(resp))
     }
 
     fn create_ipv4_udp_packet() -> Packet<Ipv4> {
@@ -757,9 +748,11 @@ mod tests {
     #[test]
     fn full_handshake() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        let init = create_handshake_init(&mut my_tun);
-        let resp = create_handshake_response(&mut their_tun, init);
-        let _keepalive = parse_handshake_resp(&mut my_tun, resp);
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        assert!(
+            matches!(result, TunnResult::WriteToNetwork(WgKind::Data(_))),
+            "expected a keepalive after the handshake, got {result:?}"
+        );
     }
 
     #[test]
@@ -839,14 +832,31 @@ mod tests {
         assert_packet_roundtrip(&mut my_tun, &mut their_tun);
     }
 
-    /// Changing the preshared key must not tear down the established session: the
-    /// PSK is not part of its transport keys, so traffic keeps flowing even
-    /// though `their_tun` never learned the new key.
+    /// Changing the preshared key only affects the next session, never the
+    /// current one. The PSK is not part of the established session's transport
+    /// keys, so traffic keeps flowing even though `their_tun` never learned the
+    /// new key. The next handshake does mix it in, so a one-sided change makes
+    /// the rekey fail to authenticate.
     #[test]
-    fn set_preshared_key_keeps_existing_session() {
+    fn set_preshared_key_only_affects_next_session() {
         let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
+
+        // Only one side adopts a new key.
         my_tun.set_preshared_key(Some([7; 32]));
+
+        // The established session is unaffected and keeps working.
         assert_packet_roundtrip(&mut my_tun, &mut their_tun);
+
+        // A second handshake needs a strictly newer timestamp than the first.
+        #[cfg(feature = "mock_instant")]
+        MockClock::advance(Duration::from_micros(1));
+
+        // The next handshake mixes in the new key, so the diverged PSK breaks it.
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        assert!(
+            matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
+            "expected the rekey to fail on the diverged PSK, got {result:?}"
+        );
     }
 
     /// Send one IP packet over the established session and assert it round-trips.
@@ -861,25 +871,38 @@ mod tests {
         assert_eq!(sent.as_bytes(), received.as_bytes());
     }
 
-    /// A stored preshared key is mixed into the next handshake: matching keys on
-    /// both sides complete it, a one-sided key fails to authenticate.
+    /// A handshake completes when both sides set the same preshared key.
     #[test]
-    fn set_preshared_key_applies_to_next_handshake() {
-        let preshared_key = [7; 32];
-
+    fn handshake_completes_with_matching_preshared_key() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        my_tun.set_preshared_key(Some(preshared_key));
-        their_tun.set_preshared_key(Some(preshared_key));
+        my_tun.set_preshared_key(Some([7; 32]));
+        their_tun.set_preshared_key(Some([7; 32]));
         complete_handshake(&mut my_tun, &mut their_tun);
+    }
 
+    /// A handshake fails to authenticate when only one side set a preshared key.
+    #[test]
+    fn handshake_fails_with_one_sided_preshared_key() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        my_tun.set_preshared_key(Some(preshared_key));
-        let init = create_handshake_init(&mut my_tun);
-        let resp = create_handshake_response(&mut their_tun, init);
-        assert!(matches!(
-            my_tun.handle_incoming_packet(WgKind::HandshakeResp(resp)),
-            TunnResult::Err(WireGuardError::InvalidAeadTag)
-        ));
+        my_tun.set_preshared_key(Some([7; 32]));
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        assert!(
+            matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
+            "expected the handshake to fail on the one-sided PSK, got {result:?}"
+        );
+    }
+
+    /// A handshake fails to authenticate when each side set a different preshared key.
+    #[test]
+    fn handshake_fails_with_different_preshared_key() {
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        my_tun.set_preshared_key(Some([7; 32]));
+        their_tun.set_preshared_key(Some([4; 32]));
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        assert!(
+            matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
+            "expected the handshake to fail on the one-sided PSK, got {result:?}"
+        );
     }
 
     /// Test that [`Tunn::update_timers`] does not panic if clock jumps back.
@@ -1029,10 +1052,7 @@ mod tests {
             ..TimerParams::default()
         });
 
-        let init = create_handshake_init(&mut my_tun);
-        let resp = create_handshake_response(&mut their_tun, init);
-        let keepalive = parse_handshake_resp(&mut my_tun, resp);
-        parse_keepalive(&mut their_tun, keepalive);
+        complete_handshake(&mut my_tun, &mut their_tun);
 
         // Receive a data packet at t = 1 s without answering. The passive keepalive
         // should fire KEEPALIVE (rather than the default 10 s) after the data arrived.


### PR DESCRIPTION
Follow up to #124. That PR made it so modify_peer/update_peer immediately invalidated any existing sessions, forcing a new handshake. Both the Linux kernel implementation and wireguard-go keeps any existing sessions valid, and only use the new PSK on the next handshake. This PR reverts GotaTun to the same behavior as those reference implementations.

A reason to not immediately invalidate the sessions is to keep the tunnel working during a PSK update. Say you have a working tunnel. You negotiate a PSK with your peer in some way. Both sides apply the new PSK. On current `main` there is no way to keep the tunnel working between the time the first peer sets the new PSK and the second peer does. With this change, the tunnel keeps working smoothly during the PSK update, and the new PSK is mixed into the session keys within <=120 seconds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/149)
<!-- Reviewable:end -->
