### PR TITLE
Fix validation of allowed IP for incoming packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the receive task, halting all UDP reception. Both single datagrams and
   GRO-coalesced segments were affected. The receive buffer now grows to fit
   them instead.
+- Fix a bug in the validation of allowed IPs for incoming packets. Peers could
+  send packets with an IP belonging to another, if the allowed IPs of the second
+  was a subnet of the first.
 
 
 ## [0.7.1] - 2026-05-26

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -670,12 +670,9 @@ impl<T: DeviceTransports> DeviceState<T> {
                         continue;
                     };
 
-                    // Cryptokey-routing reverse-path check (whitepaper §2; kernel
-                    // `wg_allowedips_lookup_src`): the inner source address must be routed to
-                    // *this* peer by longest-prefix match in the device-wide table. A per-peer
-                    // allowed-ips membership test is insufficient - with overlapping prefixes
-                    // across peers (e.g. peer A holds 10.0.0.0/24 and peer B holds 10.0.0.5/32)
-                    // it would let the broad-prefix peer spoof the more-specific peer's source.
+                    // Only accept the incoming packet if an outgoing packet to the source IP address
+                    // would be routed to the same peer. This is determined by the most specific
+                    // matching allowed IP range on the device.
                     let (source, packet): (IpAddr, _) = packet.either(
                         |ipv4| (ipv4.header.source().into(), ipv4.into()),
                         |ipv6| (ipv6.header.source().into(), ipv6.into()),

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -670,12 +670,21 @@ impl<T: DeviceTransports> DeviceState<T> {
                         continue;
                     };
 
-                    // check whether `peer` is allowed to send us packets from `source`
+                    // Cryptokey-routing reverse-path check (whitepaper §2; kernel
+                    // `wg_allowedips_lookup_src`): the inner source address must be routed to
+                    // *this* peer by longest-prefix match in the device-wide table. A per-peer
+                    // allowed-ips membership test is insufficient - with overlapping prefixes
+                    // across peers (e.g. peer A holds 10.0.0.0/24 and peer B holds 10.0.0.5/32)
+                    // it would let the broad-prefix peer spoof the more-specific peer's source.
                     let (source, packet): (IpAddr, _) = packet.either(
                         |ipv4| (ipv4.header.source().into(), ipv4.into()),
                         |ipv6| (ipv6.header.source().into(), ipv6.into()),
                     );
-                    if !peer.is_allowed_ip(source) {
+                    let routed_to_this_peer = device_guard
+                        .peers_by_ip
+                        .find(source)
+                        .is_some_and(|owner| Arc::ptr_eq(owner, &peer_arc));
+                    if !routed_to_this_peer {
                         if cfg!(debug_assertions) {
                             let unspecified = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into();
                             log::warn!(

--- a/gotatun/src/device/peer_state.rs
+++ b/gotatun/src/device/peer_state.rs
@@ -12,7 +12,7 @@
 
 use ipnetwork::IpNetwork;
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use crate::device::AllowedIps;
 #[cfg(feature = "daita")]
@@ -111,10 +111,6 @@ impl PeerState {
 
     pub fn set_endpoint(&mut self, addr: SocketAddr) {
         self.endpoint.addr = Some(addr);
-    }
-
-    pub fn is_allowed_ip<I: Into<IpAddr>>(&self, addr: I) -> bool {
-        self.allowed_ips.find(addr.into()).is_some()
     }
 
     pub fn allowed_ips(&self) -> impl Iterator<Item = IpNetwork> + '_ {

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -179,6 +179,55 @@ async fn test_endpoint_roaming() {
     ping_pong("1.2.3.4".parse().unwrap()).await;
 }
 
+/// Reverse-path / cryptokey routing: a peer must not inject a packet whose inner source IP
+/// belongs (by longest-prefix match) to a *different* peer, even when the sending peer's own
+/// allowed-ips would cover it. Regression for the per-peer-vs-device-wide desync: Alice holds
+/// 0.0.0.0/0, but 10.0.0.5/32 is owned by another peer (Carol) on Bob's device.
+#[tokio::test]
+#[test_log::test]
+async fn reverse_path_rejects_source_owned_by_another_peer() {
+    use crate::device::Peer;
+    use ipnetwork::Ipv4Network;
+    use std::net::Ipv4Addr;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    let (alice, mut bob, _eve) = mock::device_pair().await;
+
+    // A third peer "Carol" claims 10.0.0.5/32 on Bob's device. She never connects; she only
+    // owns that address in the device-wide routing table.
+    let carol_pub = PublicKey::from(&StaticSecret::random());
+    let added = bob
+        .device
+        .add_peer(
+            Peer::new(carol_pub).with_allowed_ip(
+                Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 5), 32)
+                    .unwrap()
+                    .into(),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(added);
+
+    // Sanity: a legitimately-sourced packet (within Alice's 0.0.0.0/0) is delivered. This also
+    // drives the handshake to completion.
+    let legit = mock::packet(b"hi");
+    alice.app_tx.send(legit.clone()).await;
+    let got = tokio::time::timeout(Duration::from_secs(2), bob.app_rx.recv())
+        .await
+        .expect("legit packet must be delivered");
+    assert_eq!(got.as_bytes(), legit.as_bytes());
+
+    // Alice spoofs source 10.0.0.5, which on Bob's device belongs to Carol. Bob must drop it.
+    let spoofed = mock::packet_from(Ipv4Addr::new(10, 0, 0, 5), b"spoofed");
+    alice.app_tx.send(spoofed).await;
+    let result = tokio::time::timeout(Duration::from_secs(1), bob.app_rx.recv()).await;
+    assert!(
+        result.is_err(),
+        "Bob delivered a packet whose source 10.0.0.5 is owned by a different peer"
+    );
+}
+
 /// The number of packets we send through the tunnel
 fn packet_count() -> usize {
     mock::packets_of_every_size().len()

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -179,10 +179,11 @@ async fn test_endpoint_roaming() {
     ping_pong("1.2.3.4".parse().unwrap()).await;
 }
 
-/// Reverse-path / cryptokey routing: a peer must not inject a packet whose inner source IP
-/// belongs (by longest-prefix match) to a *different* peer, even when the sending peer's own
-/// allowed-ips would cover it. Regression for the per-peer-vs-device-wide desync: Alice holds
-/// 0.0.0.0/0, but 10.0.0.5/32 is owned by another peer (Carol) on Bob's device.
+/// A peer must not inject a packet whose inner source IP belongs
+/// (by longest-prefix match) to a *different* peer, even when the
+/// sending peer's own allowed-ips would cover it. The most specific
+/// allowed IP on the device for the source address of incoming
+/// packets must belong to the peer.
 #[tokio::test]
 #[test_log::test]
 async fn reverse_path_rejects_source_owned_by_another_peer() {
@@ -191,10 +192,10 @@ async fn reverse_path_rejects_source_owned_by_another_peer() {
     use std::net::Ipv4Addr;
     use x25519_dalek::{PublicKey, StaticSecret};
 
+    // Alice has 0.0.0.0/0 as it's allowed IP range
     let (alice, mut bob, _eve) = mock::device_pair().await;
 
-    // A third peer "Carol" claims 10.0.0.5/32 on Bob's device. She never connects; she only
-    // owns that address in the device-wide routing table.
+    // Set up a third peer "Carol" with 10.0.0.5/32 on Bob's device
     let carol_pub = PublicKey::from(&StaticSecret::random());
     let added = bob
         .device
@@ -209,9 +210,8 @@ async fn reverse_path_rejects_source_owned_by_another_peer() {
         .unwrap();
     assert!(added);
 
-    // Sanity: a legitimately-sourced packet (within Alice's 0.0.0.0/0) is delivered. This also
-    // drives the handshake to completion.
-    let legit = mock::packet(b"hi");
+    // Sanity: a legitimately-sourced packet (within Alice's 0.0.0.0/0) is delivered
+    let legit = mock::packet_from(Ipv4Addr::new(192, 168, 0, 1), b"hi");
     alice.app_tx.send(legit.clone()).await;
     let got = tokio::time::timeout(Duration::from_secs(2), bob.app_rx.recv())
         .await

--- a/gotatun/src/device/tests/mock.rs
+++ b/gotatun/src/device/tests/mock.rs
@@ -196,9 +196,14 @@ pub fn mock_tun() -> (MockTun, MockAppTx, MockAppRx) {
 
 /// Create a mocked barely passable IPv4 packet containing `payload`.
 pub fn packet(payload: impl AsRef<[u8]>) -> Packet<Ip> {
+    packet_from(Ipv4Addr::new(192, 168, 0, 1), payload)
+}
+
+/// Like [`packet`] but with a chosen source address, for exercising reverse-path checks.
+pub fn packet_from(source: Ipv4Addr, payload: impl AsRef<[u8]>) -> Packet<Ip> {
     let payload = payload.as_ref();
     let packet = Ipv4Header::new(
-        Ipv4Addr::new(192, 168, 0, 1),
+        source,
         Ipv4Addr::new(192, 168, 0, 2),
         IpNextProtocol::Pup,
         payload,


### PR DESCRIPTION
Incoming packets must come from the same peer as they would be routed to given the devices allowed IP list. I.e. the most specific CIDR matching the source address must belong to the peer. Currently, we only check the peers own allowed IPs list, which makes it possible to receive packets from one peer with an IP belonging to another, in the case where the allowed IPs of the second is a subnet of the first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/150)
<!-- Reviewable:end -->
