### PR TITLE
Add suspend and awake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Device::suspend` and `Device::resume` to pause and resume all tunnel activity.
+  Suspending stops the timers, inbound, and outbound tasks (no keepalives, handshakes,
+  or data), while retaining peers and config. Resuming rebuilds the connection and
+  forces a fresh handshake. Intended for platforms such as iOS where I/O can be
+  cooperatively suspended for lower power use.
+
 ### Changed
 - Replace `log` with `tracing`.
+
+### Removed
+- Remove `AsFd` implementation for `UdpSocket`.
 
 ### Fixed
 - Do not update peer endpoint/roam on received cookie replies.
   This change is made to be consistent with Linux kernel and wireguard-go.
 - Continue with IPv4-only UDP transport on Linux when IPv6 sockets are unavailable.
-
-### Removed
-- Remove `AsFd` implementation for `UdpSocket`.
 
 
 ## [0.7.2] - 2026-06-25

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -275,6 +275,7 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
             rate_limiter: None,
             port: self.port,
             connection: None,
+            suspended: false,
             fatal_error: watch::Sender::new(None),
         };
 

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -46,6 +46,7 @@ pub struct DeviceBuilder<Udp, TunTx, TunRx> {
     // TODO: consider turning this into a typestate, and adding a special case for single peer
     peers: Vec<Peer>,
     index_table: Option<IndexTable>,
+    suspended: bool,
 
     #[cfg(target_os = "linux")]
     fwmark: Option<u32>,
@@ -80,6 +81,7 @@ impl DeviceBuilder<Nul, Nul, Nul> {
             port: 0,
             peers: Vec::new(),
             index_table: None,
+            suspended: false,
             #[cfg(target_os = "linux")]
             fwmark: None,
         }
@@ -106,6 +108,7 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
             port: self.port,
             peers: self.peers,
             index_table: self.index_table,
+            suspended: self.suspended,
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
@@ -181,6 +184,7 @@ impl<X> DeviceBuilder<X, Nul, Nul> {
             port: self.port,
             peers: self.peers,
             index_table: self.index_table,
+            suspended: self.suspended,
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
@@ -234,6 +238,14 @@ impl<X, Y, Z> DeviceBuilder<X, Y, Z> {
         self
     }
 
+    /// Set the device to be suspended or resumed on build.
+    ///
+    /// By default, the device is brought up in the resumed state.
+    pub fn suspended(mut self, suspended: bool) -> Self {
+        self.suspended = suspended;
+        self
+    }
+
     /// Specify the `SO_MARK` argument to the [`UdpTransportFactory`].
     ///
     /// You probably only want this when using [`with_default_udp`](Self::with_default_udp).
@@ -275,7 +287,7 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
             rate_limiter: None,
             port: self.port,
             connection: None,
-            suspended: false,
+            suspended: self.suspended,
             fatal_error: watch::Sender::new(None),
         };
 

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -129,6 +129,12 @@ pub(crate) struct DeviceState<T: DeviceTransports> {
     udp_factory: T::UdpTransportFactory,
     connection: Option<Connection<T>>,
 
+    /// Whether the device has been suspended via [`Device::suspend`].
+    ///
+    /// While suspended, the [`Connection`] (and all its tasks) is torn down so no
+    /// traffic flows, but peers, keys, and config are retained for [`Device::resume`].
+    suspended: bool,
+
     /// The task that responds to API requests.
     api: Option<Task>,
 
@@ -160,6 +166,16 @@ impl<T: DeviceTransports> Connection<T> {
     #[instrument(level = Level::TRACE, skip_all, ret)]
     pub async fn set_up(device_arc: Arc<RwLock<DeviceState<T>>>) -> Result<(), Error> {
         let mut device = device_arc.write().await;
+
+        // While suspended, no connection may be brought up: a reconfiguration
+        // (adding a peer, changing the key/port, a UAPI `set=1`, ...) must not
+        // silently resume the tunnel. The config change is still applied to
+        // `DeviceState`; [`Device::resume`] brings the connection up afterwards
+        // with the latest config.
+        if device.suspended {
+            return Ok(());
+        }
+
         let pool = PacketBufPool::new(MAX_PACKET_BUFS);
 
         // clean up existing connection
@@ -282,6 +298,68 @@ impl<T: DeviceTransports> Device<T> {
         if let Some(connection) = device.connection.take() {
             connection.stop().await;
         }
+    }
+
+    /// Suspend the device, stopping all tunnel activity.
+    ///
+    /// This tears down the connection and all its background tasks (timers,
+    /// inbound, and outbound I/O), so no keepalives, handshakes, or data packets are
+    /// sent or received. Peers, keys, and configuration are retained, and the device
+    /// can be brought back with [`Device::resume`].
+    ///
+    /// This is primarily intended for platforms such as iOS, where the host process
+    /// may be suspended by the system: an explicit suspend stops the timers (whose
+    /// clock keeps advancing while suspended) from waking the process and flooding
+    /// the link on resume.
+    ///
+    /// Calling this on an already-suspended device is a no-op.
+    pub async fn suspend(&self) {
+        tracing::debug!("Suspending device");
+
+        let mut device = self.inner.write().await;
+
+        if device.suspended {
+            return;
+        }
+
+        if let Some(connection) = device.connection.take() {
+            connection.stop().await;
+        }
+
+        device.suspended = true;
+    }
+
+    /// Resume a device that was suspended with [`Device::suspend`].
+    ///
+    /// This rebuilds the connection (rebinding sockets and respawning tasks).
+    /// Existing sessions are cleared first, so the tunnel performs a fresh handshake
+    /// rather than reusing a stale session.
+    ///
+    /// Calling this on a device that is not suspended is a no-op.
+    pub async fn resume(&self) -> Result<(), Error> {
+        tracing::debug!("Resuming device");
+
+        {
+            let mut device = self.inner.write().await;
+
+            if !device.suspended {
+                return Ok(());
+            }
+
+            // Force a fresh handshake on resume by dropping any existing sessions.
+            for peer in device.peers.values() {
+                peer.lock().await.reset();
+            }
+
+            device.suspended = false;
+
+            // Nothing to bring up if the device has no peers (and therefore no key).
+            if device.peers.is_empty() {
+                return Ok(());
+            }
+        }
+
+        Connection::set_up(self.inner.clone()).await
     }
 
     /// Wait until an unrecoverable error occurs.

--- a/gotatun/src/device/peer_state.rs
+++ b/gotatun/src/device/peer_state.rs
@@ -92,6 +92,11 @@ impl PeerState {
         self.tunnel.update_timers()
     }
 
+    /// Drop all sessions and reset the tunnel, forcing a fresh handshake.
+    pub fn reset(&mut self) {
+        self.tunnel.reset();
+    }
+
     #[cfg(feature = "daita")]
     pub fn daita_settings(&self) -> Option<&DaitaSettings> {
         self.daita_settings.as_ref()

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -346,6 +346,120 @@ async fn send_and_expect_delivery(
     assert_eq!(received.as_bytes(), packet.as_bytes());
 }
 
+/// [`Device::suspend`] stops all traffic; [`Device::resume`] restores it with a fresh handshake.
+#[tokio::test]
+#[test_log::test]
+async fn suspend_and_resume() {
+    use tokio::time::timeout;
+
+    let (alice, mut bob, eve) = mock::device_pair().await;
+
+    // Sniff handshake initiations across the whole test.
+    let mut inits = std::pin::pin!(eve.wg_handshake_init());
+
+    // 1. Establish the tunnel: a packet from alice must reach bob.
+    let before = b"before suspend";
+    alice.app_tx.send(mock::packet(before)).await;
+    let received = timeout(Duration::from_secs(1), bob.app_rx.recv())
+        .await
+        .expect("bob should receive alice's packet before suspend");
+    assert_eq!(received.as_bytes(), mock::packet(before).as_bytes());
+
+    // The initial handshake should have happened.
+    let first_init = timeout(Duration::from_secs(1), inits.next())
+        .await
+        .expect("a handshake init should be observed");
+    assert!(first_init.is_some());
+
+    // 2. Suspend alice. All of its tasks (timers, inbound, outbound) are now stopped.
+    alice.device.suspend().await;
+    // Suspending again is a no-op.
+    alice.device.suspend().await;
+
+    // 3. While suspended, a packet from alice must NOT reach bob.
+    let during = b"during suspend";
+    alice.app_tx.send(mock::packet(during)).await;
+    let no_delivery = timeout(Duration::from_millis(300), bob.app_rx.recv()).await;
+    assert!(
+        no_delivery.is_err(),
+        "no traffic should flow while suspended"
+    );
+
+    // Time passes while the host process is suspended. Advancing the mock clock
+    // (a no-op without the `mock_instant` feature) ensures the fresh handshake
+    // sent after resume carries a strictly later TAI64N timestamp than the first,
+    // so the peer does not reject it as a replay.
+    advance_mock_clock();
+
+    // 4. Resume alice. The buffered packet should now flow, via a fresh handshake.
+    alice.device.resume().await.expect("resume should succeed");
+    // Resuming again is a no-op.
+    alice
+        .device
+        .resume()
+        .await
+        .expect("resume should be idempotent");
+
+    let received = timeout(Duration::from_secs(2), bob.app_rx.recv())
+        .await
+        .expect("bob should receive alice's packet after resume");
+    assert_eq!(received.as_bytes(), mock::packet(during).as_bytes());
+
+    // Resume cleared alice's sessions, so a second handshake init must be observed.
+    let second_init = timeout(Duration::from_secs(2), inits.next())
+        .await
+        .expect("a fresh handshake init should be observed after resume");
+    assert!(second_init.is_some());
+
+    drop((alice, bob));
+}
+
+/// A reconfiguration that would normally rebuild the connection must not
+/// silently un-suspend the device: the change is applied to `DeviceState` but
+/// the connection stays down until [`Device::resume`].
+#[tokio::test]
+#[test_log::test]
+async fn reconfigure_while_suspended_stays_down() {
+    use tokio::time::timeout;
+
+    let (alice, mut bob, _eve) = mock::device_pair().await;
+
+    // Establish the tunnel.
+    alice.app_tx.send(mock::packet(b"before")).await;
+    timeout(Duration::from_secs(1), bob.app_rx.recv())
+        .await
+        .expect("tunnel should establish before suspend");
+
+    alice.device.suspend().await;
+
+    // A config change that internally calls `Connection::set_up`. Reuse the same
+    // listen port so the mock's source-port addressing stays intact on resume.
+    alice
+        .device
+        .set_listen_port(1)
+        .await
+        .expect("reconfigure should succeed while suspended");
+
+    // The connection must stay down: reconfiguring did not resume the tunnel.
+    let during = b"during suspend";
+    alice.app_tx.send(mock::packet(during)).await;
+    let no_delivery = timeout(Duration::from_millis(300), bob.app_rx.recv()).await;
+    assert!(
+        no_delivery.is_err(),
+        "reconfiguring while suspended must not bring the connection up"
+    );
+
+    // Resume brings the connection up with the applied config; traffic flows.
+    advance_mock_clock();
+    alice.device.resume().await.expect("resume should succeed");
+    let received = timeout(Duration::from_secs(2), bob.app_rx.recv())
+        .await
+        .expect("traffic should flow after resume");
+    assert_eq!(received.as_bytes(), mock::packet(during).as_bytes());
+
+    drop((alice, bob));
+}
+
 /// Helper method to test that packets can be sent from one [`Device`] to another.
 /// Use `eavesdrop` to sniff wireguard packets and assert things about the connection.
 async fn test_device_pair(eavesdrop: impl AsyncFnOnce(MockEavesdropper) + Send) {

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -483,6 +483,12 @@ impl Handshake {
         self.state = HandshakeState::Expired;
     }
 
+    /// Reset the handshake to its initial state, so a fresh handshake can be initiated.
+    pub(crate) fn reset(&mut self) {
+        self.previous = HandshakeState::None;
+        self.state = HandshakeState::None;
+    }
+
     pub(crate) fn is_expired(&self) -> bool {
         matches!(self.state, HandshakeState::Expired)
     }

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -150,6 +150,16 @@ impl<R: RngCore + Send> Tunn<R> {
         self.handshake.is_expired()
     }
 
+    /// Drop all sessions and reset the handshake and timing state.
+    ///
+    /// After this, the tunnel behaves as if freshly created: the next outgoing
+    /// packet (or persistent keepalive) initiates a new handshake. Used when
+    /// resuming a suspended device to avoid reusing a stale session.
+    pub fn reset(&mut self) {
+        self.clear_all();
+        self.handshake.reset();
+    }
+
     /// Update the private key and clear existing sessions.
     pub fn set_static_private(
         &mut self,

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -272,7 +272,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
 
     // We don't really clear the timers, but we set them to the current time to
     // so the reference time frame is the same
-    fn clear_all(&mut self) {
+    pub(super) fn clear_all(&mut self) {
         for session in &mut self.sessions {
             *session = None;
         }


### PR DESCRIPTION
Adding ability to suspend and wake up a GotaTun device. This is helpful when running on mobile devices - GotaTun can be suspended such timers and I/O is stopped during sleep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/156)
<!-- Reviewable:end -->
