### PR TITLE
Add ProtocolIdentifier for custom Noise protocol construction

### DIFF
--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -15,7 +15,7 @@ use tokio::sync::{Mutex, RwLock, watch};
 use x25519_dalek::StaticSecret;
 
 use crate::device::Error;
-use crate::noise::index_table::IndexTable;
+use crate::noise::{ProtocolIdentifier, index_table::IndexTable};
 #[cfg(feature = "tun")]
 use crate::tun::tun_async_device::TunDevice;
 use crate::{
@@ -46,6 +46,7 @@ pub struct DeviceBuilder<Udp, TunTx, TunRx> {
     // TODO: consider turning this into a typestate, and adding a special case for single peer
     peers: Vec<Peer>,
     index_table: Option<IndexTable>,
+    protocol_identifier: Option<ProtocolIdentifier>,
 
     #[cfg(target_os = "linux")]
     fwmark: Option<u32>,
@@ -80,6 +81,7 @@ impl DeviceBuilder<Nul, Nul, Nul> {
             port: 0,
             peers: Vec::new(),
             index_table: None,
+            protocol_identifier: None,
             #[cfg(target_os = "linux")]
             fwmark: None,
         }
@@ -106,6 +108,7 @@ impl<X, Y> DeviceBuilder<Nul, X, Y> {
             port: self.port,
             peers: self.peers,
             index_table: self.index_table,
+            protocol_identifier: self.protocol_identifier,
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
@@ -181,6 +184,7 @@ impl<X> DeviceBuilder<X, Nul, Nul> {
             port: self.port,
             peers: self.peers,
             index_table: self.index_table,
+            protocol_identifier: self.protocol_identifier,
             #[cfg(target_os = "linux")]
             fwmark: self.fwmark,
         }
@@ -234,6 +238,14 @@ impl<X, Y, Z> DeviceBuilder<X, Y, Z> {
         self
     }
 
+    /// Set the Noise protocol construction and identifier for this device.
+    ///
+    /// Both peers must use the same identifier. The default is the standard WireGuard identifier.
+    pub fn with_protocol_identifier(mut self, protocol_identifier: ProtocolIdentifier) -> Self {
+        self.protocol_identifier = Some(protocol_identifier);
+        self
+    }
+
     /// Specify the `SO_MARK` argument to the [`UdpTransportFactory`].
     ///
     /// You probably only want this when using [`with_default_udp`](Self::with_default_udp).
@@ -274,6 +286,7 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
             peers_by_ip: AllowedIps::new(),
             rate_limiter: None,
             port: self.port,
+            protocol_identifier: self.protocol_identifier.unwrap_or_default(),
             connection: None,
             fatal_error: watch::Sender::new(None),
         };

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -42,7 +42,7 @@ use tracing::{Level, instrument};
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
-use crate::noise::{Tunn, TunnResult};
+use crate::noise::{ProtocolIdentifier, Tunn, TunnResult};
 use crate::packet::{PacketBufPool, WgKind};
 use crate::task::Task;
 use crate::tun::{IpRecv, IpSend, MtuWatcher};
@@ -124,6 +124,7 @@ pub(crate) struct DeviceState<T: DeviceTransports> {
     index_table: IndexTable,
 
     rate_limiter: Option<Arc<RateLimiter>>,
+    protocol_identifier: ProtocolIdentifier,
 
     port: u16,
     udp_factory: T::UdpTransportFactory,
@@ -369,13 +370,14 @@ impl<T: DeviceTransports> DeviceState<T> {
             .expect("Setting private key creates rate limiter")
             .clone();
 
-        let mut tunn = Tunn::new(
+        let mut tunn = Tunn::new_with_protocol_identifier(
             device_key_pair.0.clone(),
             peer_builder.public_key,
             peer_builder.preshared_key,
             peer_builder.keepalive,
             self.index_table.clone(),
             rate_limiter,
+            self.protocol_identifier,
         );
 
         if let Some(timer_params) = peer_builder.danger_timer_params {
@@ -564,7 +566,7 @@ impl<T: DeviceTransports> DeviceState<T> {
         mut udp_rx: impl UdpRecv,
         mut packet_pool: PacketBufPool,
     ) -> Result<(), Error> {
-        let (private_key, public_key, rate_limiter, mut tun_mtu) = {
+        let (private_key, public_key, rate_limiter, protocol_identifier, mut tun_mtu) = {
             let Some(device) = device.upgrade() else {
                 return Ok(());
             };
@@ -573,7 +575,13 @@ impl<T: DeviceTransports> DeviceState<T> {
             let (private_key, public_key) = device.key_pair.clone().expect("Key not set");
             let rate_limiter = device.rate_limiter.clone().unwrap();
             let tun_mtu = device.tun_rx_mtu.clone();
-            (private_key, public_key, rate_limiter, tun_mtu)
+            (
+                private_key,
+                public_key,
+                rate_limiter,
+                device.protocol_identifier,
+                tun_mtu,
+            )
         };
 
         while let Ok((src_buf, addr)) = udp_rx.recv_from(&mut packet_pool).await {
@@ -597,10 +605,12 @@ impl<T: DeviceTransports> DeviceState<T> {
             let device_guard = device.read().await;
             let peers = &device_guard.peers;
             let peer = match &parsed_packet {
-                WgKind::HandshakeInit(p) => parse_handshake_anon(&private_key, &public_key, p)
-                    .ok()
-                    .and_then(|hh| peers.get(&x25519::PublicKey::from(hh.peer_static_public)))
-                    .cloned(),
+                WgKind::HandshakeInit(p) => {
+                    parse_handshake_anon(&private_key, &public_key, &protocol_identifier, p)
+                        .ok()
+                        .and_then(|hh| peers.get(&x25519::PublicKey::from(hh.peer_static_public)))
+                        .cloned()
+                }
                 WgKind::HandshakeResp(p) => device_guard
                     .peers_by_idx
                     .lock()

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use zerocopy::IntoBytes;
 
-use crate::noise::index_table::IndexTable;
+use crate::noise::{ProtocolIdentifier, index_table::IndexTable};
 use crate::packet::{Ip, Packet};
 
 pub mod mock;
@@ -267,6 +267,25 @@ async fn update_peer_preshared_key_reaches_tunnel() {
         advance_mock_clock();
     })
     .await;
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn custom_protocol_identifier_device_pair() {
+    let protocol_identifier = ProtocolIdentifier::new(
+        b"gotatun custom construction test",
+        b"gotatun custom protocol test",
+    );
+    let (alice, mut bob, _eve) =
+        mock::device_pair_with_protocol_identifier(protocol_identifier).await;
+    let packet = mock::packet(b"Hello!");
+
+    alice.app_tx.send(packet.clone()).await;
+    let received = tokio::time::timeout(Duration::from_secs(1), bob.app_rx.recv())
+        .await
+        .expect("custom protocol identifier handshake timed out");
+
+    assert_eq!(received.as_bytes(), packet.as_bytes());
 }
 
 /// The number of packets we send through the tunnel

--- a/gotatun/src/device/tests/mock.rs
+++ b/gotatun/src/device/tests/mock.rs
@@ -30,7 +30,7 @@ use zerocopy::IntoBytes;
 
 use crate::{
     device::{Device, DeviceBuilder, Peer},
-    noise::index_table::IndexTable,
+    noise::{ProtocolIdentifier, index_table::IndexTable},
     packet::{
         Ip, IpNextProtocol, Ipv4, Ipv4Header, Ipv6, Packet, PacketBufPool, Udp, WgData,
         WgHandshakeInit, WgHandshakeResp, WgKind,
@@ -48,6 +48,12 @@ pub const BOB_INDEX_SEED: u64 = 2;
 pub const TUN_MTU: u16 = 1360;
 
 pub async fn device_pair() -> (MockDevice, MockDevice, MockEavesdropper) {
+    device_pair_with_protocol_identifier(ProtocolIdentifier::standard()).await
+}
+
+pub async fn device_pair_with_protocol_identifier(
+    protocol_identifier: ProtocolIdentifier,
+) -> (MockDevice, MockDevice, MockEavesdropper) {
     let (mock_tun_a, mock_app_tx_a, mock_app_rx_a) = mock_tun();
     let (mock_tun_b, mock_app_tx_b, mock_app_rx_b) = mock_tun();
 
@@ -144,6 +150,7 @@ pub async fn device_pair() -> (MockDevice, MockDevice, MockEavesdropper) {
         .with_udp(udp_alice)
         .with_listen_port(port) // TODO: is this necessary?
         .with_peer(peer_b)
+        .with_protocol_identifier(protocol_identifier)
         .with_index_table(IndexTable::from_rng(StdRng::seed_from_u64(
             ALICE_INDEX_SEED,
         )))
@@ -157,6 +164,7 @@ pub async fn device_pair() -> (MockDevice, MockDevice, MockEavesdropper) {
         .with_udp(udp_bob)
         .with_listen_port(port) // TODO: is this necessary?
         .with_peer(peer_a)
+        .with_protocol_identifier(protocol_identifier)
         .with_index_table(IndexTable::from_rng(StdRng::seed_from_u64(BOB_INDEX_SEED)))
         .build()
         .await

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -35,17 +35,61 @@ pub(crate) const LABEL_COOKIE: &[u8; 8] = b"cookie--";
 const KEY_LEN: usize = 32;
 const TIMESTAMP_LEN: usize = 12;
 
-// initiator.chaining_key = HASH(CONSTRUCTION)
-const INITIAL_CHAIN_KEY: [u8; KEY_LEN] = [
-    96, 226, 109, 174, 243, 39, 239, 192, 46, 195, 53, 226, 160, 37, 210, 208, 22, 235, 66, 6, 248,
-    114, 119, 245, 45, 56, 209, 152, 139, 120, 205, 54,
-];
+/// WireGuard Noise protocol construction and identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProtocolIdentifier {
+    initial_chain_key: [u8; KEY_LEN],
+    initial_chain_hash: [u8; KEY_LEN],
+}
 
-// initiator.chaining_hash = HASH(initiator.chaining_key || IDENTIFIER)
-const INITIAL_CHAIN_HASH: [u8; KEY_LEN] = [
-    34, 17, 179, 97, 8, 26, 197, 102, 105, 18, 67, 219, 69, 138, 213, 50, 45, 156, 108, 102, 34,
-    147, 232, 183, 14, 225, 156, 101, 186, 7, 158, 243,
-];
+impl ProtocolIdentifier {
+    const STANDARD_NOISE_CONSTRUCTION: &[u8] = b"Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+    const STANDARD_PROTOCOL_IDENTIFIER: &[u8] = b"WireGuard v1 zx2c4 Jason@zx2c4.com";
+
+    /// Return the standard WireGuard protocol construction and identifier.
+    pub fn standard() -> Self {
+        Self::new(
+            Self::STANDARD_NOISE_CONSTRUCTION,
+            Self::STANDARD_PROTOCOL_IDENTIFIER,
+        )
+    }
+
+    /// Create a protocol identifier from arbitrary construction and identifier bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either value is empty.
+    pub fn new(construction: impl AsRef<[u8]>, identifier: impl AsRef<[u8]>) -> Self {
+        let construction = construction.as_ref();
+        let identifier = identifier.as_ref();
+
+        let initial_chain_key = b2s_hash(construction, &[]);
+        let initial_chain_hash = b2s_hash(&initial_chain_key, identifier);
+
+        Self {
+            initial_chain_key,
+            initial_chain_hash,
+        }
+    }
+
+    /// Return the initial chain key.
+    /// initial chain key = HASH(construction)
+    pub(crate) fn initial_chain_key(&self) -> [u8; 32] {
+        self.initial_chain_key
+    }
+
+    /// Return the initial chain hash.
+    /// initial chain hash = HASH(initial chain key || identifier)
+    pub(crate) fn initial_chain_hash(&self) -> [u8; KEY_LEN] {
+        self.initial_chain_hash
+    }
+}
+
+impl Default for ProtocolIdentifier {
+    fn default() -> Self {
+        Self::standard()
+    }
+}
 
 #[inline]
 pub(crate) fn b2s_hash(data1: &[u8], data2: &[u8]) -> [u8; 32] {
@@ -253,6 +297,8 @@ struct NoiseParams {
     sending_mac1_key: [u8; KEY_LEN],
     /// An optional preshared key
     preshared_key: Option<[u8; KEY_LEN]>,
+    /// The agreed Noise protocol identifier
+    protocol_identifier: ProtocolIdentifier,
 }
 
 impl std::fmt::Debug for NoiseParams {
@@ -264,6 +310,7 @@ impl std::fmt::Debug for NoiseParams {
             .field("static_shared", &"<redacted>")
             .field("sending_mac1_key", &self.sending_mac1_key)
             .field("preshared_key", &self.preshared_key)
+            .field("protocol_identifier", &self.protocol_identifier)
             .finish()
     }
 }
@@ -355,13 +402,14 @@ pub struct HalfHandshake {
 pub fn parse_handshake_anon(
     static_private: &x25519::StaticSecret,
     static_public: &x25519::PublicKey,
+    protocol_identifier: &ProtocolIdentifier,
     packet: &WgHandshakeInit,
 ) -> Result<HalfHandshake, WireGuardError> {
     let peer_index = packet.sender_idx.get();
     // initiator.chaining_key = HASH(CONSTRUCTION)
-    let mut chaining_key = INITIAL_CHAIN_KEY;
+    let mut chaining_key = protocol_identifier.initial_chain_key();
     // initiator.hash = HASH(HASH(initiator.chaining_key || IDENTIFIER) || responder.static_public)
-    let mut hash = INITIAL_CHAIN_HASH;
+    let mut hash = protocol_identifier.initial_chain_hash();
     hash = b2s_hash(&hash, static_public.as_bytes());
     // msg.unencrypted_ephemeral = DH_PUBKEY(initiator.ephemeral_private)
     let peer_ephemeral_public = x25519::PublicKey::from(packet.unencrypted_ephemeral);
@@ -404,6 +452,7 @@ impl NoiseParams {
         static_public: x25519::PublicKey,
         peer_static_public: x25519::PublicKey,
         preshared_key: Option<[u8; 32]>,
+        protocol_identifier: ProtocolIdentifier,
     ) -> NoiseParams {
         let static_shared = static_private.diffie_hellman(&peer_static_public);
 
@@ -416,6 +465,7 @@ impl NoiseParams {
             static_shared,
             sending_mac1_key: initial_sending_mac_key,
             preshared_key,
+            protocol_identifier,
         }
     }
 
@@ -447,12 +497,14 @@ impl Handshake {
         peer_static_public: x25519::PublicKey,
         index_table: IndexTable,
         preshared_key: Option<[u8; 32]>,
+        protocol_identifier: ProtocolIdentifier,
     ) -> Handshake {
         let params = NoiseParams::new(
             static_private,
             static_public,
             peer_static_public,
             preshared_key,
+            protocol_identifier,
         );
 
         Handshake {
@@ -523,9 +575,9 @@ impl Handshake {
         packet: crate::packet::Packet<WgHandshakeInit>,
     ) -> Result<(crate::packet::Packet<WgHandshakeResp>, Session), WireGuardError> {
         // initiator.chaining_key = HASH(CONSTRUCTION)
-        let mut chaining_key = INITIAL_CHAIN_KEY;
+        let mut chaining_key = self.params.protocol_identifier.initial_chain_key();
         // initiator.hash = HASH(HASH(initiator.chaining_key || IDENTIFIER) || responder.static_public)
-        let mut hash = INITIAL_CHAIN_HASH;
+        let mut hash = self.params.protocol_identifier.initial_chain_hash();
         hash = b2s_hash(&hash, self.params.static_public.as_bytes());
         // msg.sender_index = little_endian(initiator.sender_index)
         let peer_index = packet.sender_idx;
@@ -759,9 +811,9 @@ impl Handshake {
         let local_index_val = local_index.value();
 
         // initiator.chaining_key = HASH(CONSTRUCTION)
-        let mut chaining_key = INITIAL_CHAIN_KEY;
+        let mut chaining_key = self.params.protocol_identifier.initial_chain_key();
         // initiator.hash = HASH(HASH(initiator.chaining_key || IDENTIFIER) || responder.static_public)
-        let mut hash = INITIAL_CHAIN_HASH;
+        let mut hash = self.params.protocol_identifier.initial_chain_hash();
         hash = b2s_hash(&hash, self.params.peer_static_public.as_bytes());
         // initiator.ephemeral_private = DH_GENERATE()
         let ephemeral_private = x25519::ReusableSecret::random_from_rng(rand_core::OsRng);
@@ -923,6 +975,30 @@ impl Handshake {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // initiator.chaining_key = HASH(CONSTRUCTION)
+    const STANDARD_INITIAL_CHAIN_KEY: [u8; KEY_LEN] = [
+        96, 226, 109, 174, 243, 39, 239, 192, 46, 195, 53, 226, 160, 37, 210, 208, 22, 235, 66, 6,
+        248, 114, 119, 245, 45, 56, 209, 152, 139, 120, 205, 54,
+    ];
+
+    // initiator.chaining_hash = HASH(initiator.chaining_key || IDENTIFIER)
+    const STANDARD_INITIAL_CHAIN_HASH: [u8; KEY_LEN] = [
+        34, 17, 179, 97, 8, 26, 197, 102, 105, 18, 67, 219, 69, 138, 213, 50, 45, 156, 108, 102,
+        34, 147, 232, 183, 14, 225, 156, 101, 186, 7, 158, 243,
+    ];
+
+    #[test]
+    fn standard_protocol_identifier_matches_wireguard_test_vectors() {
+        assert_eq!(
+            ProtocolIdentifier::standard().initial_chain_key(),
+            STANDARD_INITIAL_CHAIN_KEY
+        );
+        assert_eq!(
+            ProtocolIdentifier::standard().initial_chain_hash(),
+            STANDARD_INITIAL_CHAIN_HASH
+        );
+    }
 
     #[test]
     fn chacha20_seal_rfc7530_test_vector() {

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -24,6 +24,8 @@ pub mod rate_limiter;
 mod session;
 mod timers;
 
+pub use crate::noise::handshake::ProtocolIdentifier;
+
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use zerocopy::IntoBytes;
 
@@ -98,7 +100,28 @@ impl Tunn<StdRng> {
         index_table: IndexTable,
         rate_limiter: Arc<RateLimiter>,
     ) -> Self {
-        Self::new_with_rng(
+        Self::new_with_protocol_identifier(
+            static_private,
+            peer_static_public,
+            preshared_key,
+            persistent_keepalive,
+            index_table,
+            rate_limiter,
+            ProtocolIdentifier::standard(),
+        )
+    }
+
+    /// Create a new tunnel using a custom Noise protocol construction and identifier.
+    pub fn new_with_protocol_identifier(
+        static_private: x25519::StaticSecret,
+        peer_static_public: x25519::PublicKey,
+        preshared_key: Option<[u8; 32]>,
+        persistent_keepalive: Option<u16>,
+        index_table: IndexTable,
+        rate_limiter: Arc<RateLimiter>,
+        protocol_identifier: ProtocolIdentifier,
+    ) -> Self {
+        Self::new_with_rng_and_protocol_identifier(
             static_private,
             peer_static_public,
             preshared_key,
@@ -106,6 +129,7 @@ impl Tunn<StdRng> {
             index_table,
             rate_limiter,
             StdRng::from_os_rng(),
+            protocol_identifier,
         )
     }
 }
@@ -121,6 +145,29 @@ impl<R: RngCore + Send> Tunn<R> {
         rate_limiter: Arc<RateLimiter>,
         jitter_rng: R,
     ) -> Self {
+        Self::new_with_rng_and_protocol_identifier(
+            static_private,
+            peer_static_public,
+            preshared_key,
+            persistent_keepalive,
+            index_table,
+            rate_limiter,
+            jitter_rng,
+            ProtocolIdentifier::standard(),
+        )
+    }
+
+    /// Create a new tunnel using a custom Noise protocol construction, identifier, and RNG.
+    pub fn new_with_rng_and_protocol_identifier(
+        static_private: x25519::StaticSecret,
+        peer_static_public: x25519::PublicKey,
+        preshared_key: Option<[u8; 32]>,
+        persistent_keepalive: Option<u16>,
+        index_table: IndexTable,
+        rate_limiter: Arc<RateLimiter>,
+        jitter_rng: R,
+        protocol_identifier: ProtocolIdentifier,
+    ) -> Self {
         let static_public = x25519::PublicKey::from(&static_private);
 
         Tunn {
@@ -130,6 +177,7 @@ impl<R: RngCore + Send> Tunn<R> {
                 peer_static_public,
                 index_table,
                 preshared_key,
+                protocol_identifier,
             ),
             sessions: Default::default(),
             current: Default::default(),
@@ -536,6 +584,19 @@ mod tests {
     use mock_instant::thread_local::MockClock;
 
     fn create_two_tuns() -> (Tunn, Tunn) {
+        create_two_tuns_with_protocol_identifier(ProtocolIdentifier::standard())
+    }
+
+    fn create_two_tuns_with_protocol_identifier(
+        protocol_identifier: ProtocolIdentifier,
+    ) -> (Tunn, Tunn) {
+        create_two_tuns_with_protocol_identifiers(protocol_identifier, protocol_identifier)
+    }
+
+    fn create_two_tuns_with_protocol_identifiers(
+        my_protocol_identifier: ProtocolIdentifier,
+        their_protocol_identifier: ProtocolIdentifier,
+    ) -> (Tunn, Tunn) {
         let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
         let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
 
@@ -543,23 +604,25 @@ mod tests {
         let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
 
         let rate_limiter = Arc::new(RateLimiter::new(&my_public_key, HANDSHAKE_RATE_LIMIT));
-        let my_tun = Tunn::new(
+        let my_tun = Tunn::new_with_protocol_identifier(
             my_secret_key,
             their_public_key,
             None,
             None,
             IndexTable::from_os_rng(),
             rate_limiter,
+            my_protocol_identifier,
         );
 
         let rate_limiter = Arc::new(RateLimiter::new(&their_public_key, HANDSHAKE_RATE_LIMIT));
-        let their_tun = Tunn::new(
+        let their_tun = Tunn::new_with_protocol_identifier(
             their_secret_key,
             my_public_key,
             None,
             None,
             IndexTable::from_os_rng(),
             rate_limiter,
+            their_protocol_identifier,
         );
 
         (my_tun, their_tun)
@@ -753,6 +816,52 @@ mod tests {
             matches!(result, TunnResult::WriteToNetwork(WgKind::Data(_))),
             "expected a keepalive after the handshake, got {result:?}"
         );
+    }
+
+    #[test]
+    fn custom_protocol_identifier_full_handshake() {
+        let protocol_identifier = ProtocolIdentifier::new(
+            b"gotatun custom construction test",
+            b"gotatun custom protocol test",
+        );
+        let (mut my_tun, mut their_tun) =
+            create_two_tuns_with_protocol_identifier(protocol_identifier);
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        let TunnResult::WriteToNetwork(WgKind::Data(keepalive)) = result else {
+            panic!("expected a keepalive packet after the handshake, got {result:?}");
+        };
+        parse_keepalive(&mut their_tun, keepalive);
+    }
+
+    #[test]
+    fn custom_construction_full_handshake() {
+        let protocol_identifier =
+            ProtocolIdentifier::new(b"gotatun custom construction test", b"gotatun");
+        let (mut my_tun, mut their_tun) =
+            create_two_tuns_with_protocol_identifier(protocol_identifier);
+        let result = try_handshake(&mut my_tun, &mut their_tun);
+        let TunnResult::WriteToNetwork(WgKind::Data(keepalive)) = result else {
+            panic!("expected a keepalive packet after the handshake, got {result:?}");
+        };
+        parse_keepalive(&mut their_tun, keepalive);
+    }
+
+    #[test]
+    fn mismatched_protocol_identifier_rejects_handshake() {
+        let protocol_identifier = ProtocolIdentifier::new(
+            b"gotatun custom construction test",
+            b"gotatun custom protocol test",
+        );
+        let (mut my_tun, mut their_tun) = create_two_tuns_with_protocol_identifiers(
+            ProtocolIdentifier::standard(),
+            protocol_identifier,
+        );
+
+        let init = create_handshake_init(&mut my_tun);
+        assert!(matches!(
+            their_tun.handle_incoming_packet(WgKind::HandshakeInit(init)),
+            TunnResult::Err(WireGuardError::InvalidAeadTag)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces support for customizable Noise protocol construction and identifiers in the WireGuard implementation. It adds a new `ProtocolIdentifier` type, allows devices to be configured with custom protocol identifiers, and ensures that all handshake and session logic uses the correct protocol parameters. Additionally, comprehensive tests are added to verify interoperability with custom protocol identifiers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/157)
<!-- Reviewable:end -->
