### PR TITLE
Don't roam peer endpoint on cookie replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Replace `log` with `tracing`.
 
+### Fixed
+- Do not update peer endpoint/roam on received cookie replies.
+  This change is made to be consistent with Linux kernel and wireguard-go.
+
 
 ## [0.7.2] - 2026-06-25
 ### Added

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -627,8 +627,8 @@ impl<T: DeviceTransports> DeviceState<T> {
 
             match tunnel.handle_incoming_packet(parsed_packet) {
                 TunnResult::Done => {
-                    // Update the peer endpoint if we received any authenticated packet
-                    peer.set_endpoint(addr);
+                    // Don't update the peer endpoint on cookie replies, for consistency
+                    // with both the Linux kernel and wireguard-go.
                 }
                 TunnResult::Err(_) => continue,
                 // Flush pending queue


### PR DESCRIPTION
gotatun updates a peer's endpoint on any authenticated packet, including
cookie replies. Upstream WireGuard implementations only roam on handshake
initiations/responses and transport data. An attacker could abuse this to
fingerprint which WireGuard implementation a peer uses. An attacker that can
observe the WireGuard traffic between two peers could also replay a _recently_
captured cookie reply from a spoofed source, incorrectly updating the peer's
endpoint address.

This drops `set_endpoint` from the `TunnResult::Done` arm (produced only by the cookie-reply path).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/159)
<!-- Reviewable:end -->
