### PR TITLE
Handle unavailable IPv6 UDP sockets on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Do not update peer endpoint/roam on received cookie replies.
   This change is made to be consistent with Linux kernel and wireguard-go.
+- Continue with IPv4-only UDP transport on Linux when IPv6 sockets are unavailable.
+
+### Removed
+- Remove `AsFd` implementation for `UdpSocket`.
 
 
 ## [0.7.2] - 2026-06-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "aead",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ either = "1.15.0"
 etherparse = "0.13"
 eyre = "0.6.12"
 futures = "0.3.31"
-gotatun = { path = "./gotatun", version = "0.7.2", default-features = false }
+gotatun = { path = "./gotatun", version = "0.8.0", default-features = false }
 hex = "0.4.3"
 hmac = "0.12.1"
 ip_network = "0.4.1"

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gotatun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.7.2"
+version = "0.8.0"
 authors.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/gotatun/src/udp/socket/generic.rs
+++ b/gotatun/src/udp/socket/generic.rs
@@ -23,7 +23,7 @@ impl UdpSend for super::UdpSocket {
     type SendManyBuf = ();
 
     async fn send_to(&self, packet: Packet, target: SocketAddr) -> io::Result<()> {
-        self.inner.send_to(&packet, target).await?;
+        self.socket()?.send_to(&packet, target).await?;
         Ok(())
     }
 
@@ -37,7 +37,7 @@ impl UdpRecv for super::UdpSocket {
 
     async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
         let mut buf = pool.get();
-        let (n, src) = self.inner.recv_from(&mut buf).await?;
+        let (n, src) = self.socket()?.recv_from(&mut buf).await?;
         buf.truncate(n);
         Ok((buf, src))
     }

--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -36,7 +36,7 @@ impl UdpSend for super::UdpSocket {
     type SendManyBuf = SendmmsgBuf;
 
     async fn send_to(&self, packet: Packet, target: SocketAddr) -> io::Result<()> {
-        tokio::net::UdpSocket::send_to(&self.inner, &packet, target).await?;
+        tokio::net::UdpSocket::send_to(self.socket()?, &packet, target).await?;
         Ok(())
     }
 
@@ -47,7 +47,8 @@ impl UdpSend for super::UdpSocket {
     ) -> io::Result<()> {
         check_send_max_number_of_packets(MAX_PACKET_COUNT, packets)?;
 
-        let fd = self.inner.as_raw_fd();
+        let socket = self.socket()?;
+        let fd = socket.as_raw_fd();
 
         buf.targets.clear();
 
@@ -63,8 +64,7 @@ impl UdpSend for super::UdpSocket {
         let pkts = &packets_buf[..len];
         let mut packet_buf_start = 0;
         while packet_buf_start < len {
-            let result = self
-                .inner
+            let result = socket
                 .async_io(Interest::WRITABLE, || {
                     let mut multiheaders =
                         MultiHeaders::preallocate(pkts[packet_buf_start..].len(), None);
@@ -94,12 +94,21 @@ impl UdpSend for super::UdpSocket {
     }
 
     fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        #[cfg(target_os = "linux")]
+        if self.is_disabled_ipv6() {
+            return Ok(None);
+        }
+
         UdpSocket::local_addr(self).map(Some)
     }
 
     #[cfg(target_os = "linux")]
     fn set_fwmark(&self, mark: u32) -> io::Result<()> {
-        setsockopt(&self.inner, sockopt::Mark, &mark)?;
+        if self.is_disabled_ipv6() {
+            return Ok(());
+        }
+
+        setsockopt(self.socket()?, sockopt::Mark, &mark)?;
         Ok(())
     }
 }
@@ -112,6 +121,7 @@ mod gro {
     // TODO: Fix constant
     const MAX_GRO_SIZE: usize = MAX_SEGMENTS * 4096;
 
+    use super::super::disabled_ipv6_error;
     use super::MAX_PACKET_COUNT;
     use crate::packet::{Packet, PacketBufPool};
     use crate::udp::{UdpRecv, socket::UdpSocket};
@@ -145,8 +155,12 @@ mod gro {
             &mut self,
             pool: &mut PacketBufPool,
         ) -> io::Result<(Packet, SocketAddr)> {
+            if self.is_disabled_ipv6() {
+                return Err(disabled_ipv6_error());
+            }
+
             let mut buf = pool.get();
-            let (n, src) = self.inner.recv_from(&mut buf).await?;
+            let (n, src) = self.socket()?.recv_from(&mut buf).await?;
             buf.truncate(n);
             Ok((buf, src))
         }
@@ -157,9 +171,14 @@ mod gro {
             pool: &mut PacketBufPool,
             packets: &mut Vec<(Packet, SocketAddr)>,
         ) -> io::Result<()> {
-            let fd = self.inner.as_raw_fd();
+            if self.is_disabled_ipv6() {
+                return Err(disabled_ipv6_error());
+            }
 
-            self.inner
+            let socket = self.socket()?;
+            let fd = socket.as_raw_fd();
+
+            socket
                 .async_io(Interest::READABLE, move || {
                     // TODO: the CMSG space cannot be reused, so we must allocate new headers each
                     // time [ControlMessageOwned::UdpGroSegments(i32)] contains
@@ -246,10 +265,14 @@ mod gro {
         }
 
         fn enable_udp_gro(&self) -> io::Result<()> {
+            if self.is_disabled_ipv6() {
+                return Ok(());
+            }
+
             // TODO: missing constants on Android
             use std::os::fd::AsFd;
             nix::sys::socket::setsockopt(
-                &self.inner.as_fd(),
+                &self.socket()?.as_fd(),
                 nix::sys::socket::sockopt::UdpGroSegment,
                 &true,
             )?;
@@ -361,7 +384,7 @@ mod android {
             pool: &mut PacketBufPool,
         ) -> io::Result<(Packet, SocketAddr)> {
             let mut buf = pool.get();
-            let (n, src) = self.inner.recv_from(&mut buf).await?;
+            let (n, src) = self.socket()?.recv_from(&mut buf).await?;
             buf.truncate(n);
             Ok((buf, src))
         }

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -11,8 +11,6 @@
 
 //! Implementations of [`super::UdpSend`] and [`super::UdpRecv`] traits for [`UdpSocket`].
 
-#[cfg(unix)]
-use std::os::fd::AsFd;
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -59,7 +57,21 @@ impl UdpTransportFactory for UdpSocketFactory {
             send_buffer_size: self.send_buffer_size,
         };
 
-        let (udp_v4, udp_v6) = bind_sockets(params.addr_v4, params.addr_v6, params.port, opts)?;
+        let (udp_v4, udp_v6) = cfg_select! {
+            target_os = "linux" => {
+                match bind_sockets(params.addr_v4, params.addr_v6, params.port, opts) {
+                    Err(err) if is_ipv6_unavailable(&err) => {
+                        tracing::warn!(
+                            "IPv6 UDP sockets are unavailable; continuing with IPv4-only UDP transport"
+                        );
+                        let udp_v4 = bind_ipv4_socket(params.addr_v4, params.port, opts)?;
+                        (udp_v4, UdpSocket::disabled_ipv6())
+                    }
+                    sockets => sockets?
+                }
+            }
+            _ => { bind_sockets(params.addr_v4, params.addr_v6, params.port, opts)? }
+        };
 
         if let Err(err) = udp_v4.enable_udp_gro() {
             tracing::warn!("Failed to enable UDP GRO for IPv4 socket: {err}");
@@ -68,14 +80,23 @@ impl UdpTransportFactory for UdpSocketFactory {
             tracing::warn!("Failed to enable UDP GRO for IPv6 socket: {err}");
         }
 
-        Ok(((udp_v4.clone(), udp_v4), (udp_v6.clone(), udp_v6)))
+        let udp_v6 = (udp_v6.clone(), udp_v6);
+
+        Ok(((udp_v4.clone(), udp_v4), udp_v6))
     }
 }
 
 /// Default UDP socket implementation
 #[derive(Clone)]
 pub struct UdpSocket {
-    inner: Arc<tokio::net::UdpSocket>,
+    inner: UdpSocketInner,
+}
+
+#[derive(Clone)]
+enum UdpSocketInner {
+    Socket(Arc<tokio::net::UdpSocket>),
+    #[cfg(target_os = "linux")]
+    DisabledIpv6,
 }
 
 /// Options set on the socket created by [`UdpSocket::bind`].
@@ -139,13 +160,34 @@ impl UdpSocket {
         let inner = tokio::net::UdpSocket::from_std(udp_sock.into())?;
 
         Ok(Self {
-            inner: Arc::new(inner),
+            inner: UdpSocketInner::Socket(Arc::new(inner)),
         })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn disabled_ipv6() -> Self {
+        Self {
+            inner: UdpSocketInner::DisabledIpv6,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn is_disabled_ipv6(&self) -> bool {
+        matches!(&self.inner, UdpSocketInner::DisabledIpv6)
+    }
+
+    #[inline(always)]
+    pub(crate) fn socket(&self) -> io::Result<&tokio::net::UdpSocket> {
+        match &self.inner {
+            UdpSocketInner::Socket(socket) => Ok(socket),
+            #[cfg(target_os = "linux")]
+            UdpSocketInner::DisabledIpv6 => Err(disabled_ipv6_error()),
+        }
     }
 
     /// Returns the local address that this socket is bound to.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.inner.local_addr()
+        self.socket()?.local_addr()
     }
 }
 
@@ -170,6 +212,11 @@ fn bind_sockets(
             Ok((udp_v4, udp_v6))
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn bind_ipv4_socket(addr_v4: Ipv4Addr, port: u16, opts: SockOpt) -> io::Result<UdpSocket> {
+    UdpSocket::bind((addr_v4, port).into(), opts)
 }
 
 /// When using a random port, the port chosen for IPv4 might already be in use on IPv6.
@@ -199,6 +246,22 @@ fn bind_v6_with_retry(
     Ok((udp_v4, udp_v6))
 }
 
+#[cfg(target_os = "linux")]
+fn is_ipv6_unavailable(err: &io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(libc::EAFNOSUPPORT | libc::EADDRNOTAVAIL)
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn disabled_ipv6_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "IPv6 UDP sockets are unavailable",
+    )
+}
+
 fn is_bind_retry_error(err: &io::Error) -> bool {
     #[cfg(not(target_os = "windows"))]
     {
@@ -212,17 +275,76 @@ fn is_bind_retry_error(err: &io::Error) -> bool {
     }
 }
 
-#[cfg(unix)]
-impl AsFd for UdpSocket {
-    fn as_fd(&self) -> std::os::unix::prelude::BorrowedFd<'_> {
-        self.inner.as_fd()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use crate::packet::{Packet, PacketBufPool};
+    #[cfg(target_os = "linux")]
+    use crate::udp::{UdpRecv, UdpSend};
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn recognizes_unavailable_ipv6_errors() {
+        let error = io::Error::from_raw_os_error(libc::EAFNOSUPPORT);
+        assert!(is_ipv6_unavailable(&error));
+
+        let error = io::Error::from_raw_os_error(libc::EADDRNOTAVAIL);
+        assert!(is_ipv6_unavailable(&error));
+
+        let error = io::Error::from(io::ErrorKind::AddrInUse);
+        assert!(!is_ipv6_unavailable(&error));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn disabled_ipv6_send_returns_unsupported() {
+        let socket = UdpSocket::disabled_ipv6();
+        let error = socket
+            .send_to(Packet::default(), (Ipv6Addr::LOCALHOST, 1).into())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn disabled_ipv6_recv_returns_unsupported() {
+        let mut socket = UdpSocket::disabled_ipv6();
+        let mut pool = PacketBufPool::new(1);
+        let mut recv_many_buf = <UdpSocket as UdpRecv>::RecvManyBuf::default();
+        let mut packets = Vec::new();
+
+        let error = socket.recv_from(&mut pool).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+
+        let error = socket
+            .recv_many_from(&mut recv_many_buf, &mut pool, &mut packets)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn disabled_ipv6_socket_options_are_noops() {
+        let socket = UdpSocket::disabled_ipv6();
+
+        assert!(socket.set_fwmark(1).is_ok());
+        assert!(socket.enable_udp_gro().is_ok());
+        assert_eq!(UdpSend::local_addr(&socket).unwrap(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn bind_ipv4_socket_uses_ipv4() {
+        let socket =
+            bind_ipv4_socket(Ipv4Addr::LOCALHOST, 0, SockOpt::default()).expect("bind IPv4");
+
+        assert!(socket.local_addr().unwrap().is_ipv4());
+    }
 
     /// Test that `bind_sockets` retries when the IPv6 port is already in use.
     ///

--- a/gotatun/src/udp/socket/windows.rs
+++ b/gotatun/src/udp/socket/windows.rs
@@ -48,7 +48,7 @@ impl UdpSend for super::UdpSocket {
     type SendManyBuf = SendmmsgBuf;
 
     async fn send_to(&self, packet: Packet, target: SocketAddr) -> io::Result<()> {
-        tokio::net::UdpSocket::send_to(&self.inner, &packet, target).await?;
+        tokio::net::UdpSocket::send_to(self.socket()?, &packet, target).await?;
         Ok(())
     }
 
@@ -67,7 +67,8 @@ impl UdpSend for super::UdpSocket {
 
         check_send_max_number_of_packets(*MAX_GSO_SEGMENTS, packets)?;
 
-        let client_socket_ref = socket2::SockRef::from(&*self.inner);
+        let socket = self.socket()?;
+        let client_socket_ref = socket2::SockRef::from(socket);
 
         let mut packets_iter = packets.drain(..);
         let mut saved_packet = None;
@@ -123,7 +124,7 @@ impl UdpSend for super::UdpSocket {
                 continue;
             }
 
-            self.inner
+            socket
                 .async_io(Interest::WRITABLE, || {
                     use std::io::IoSlice;
 
@@ -162,7 +163,7 @@ impl UdpRecv for super::UdpSocket {
 
     async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
         let mut buf = pool.get();
-        let (n, src) = self.inner.recv_from(&mut buf).await?;
+        let (n, src) = self.socket()?.recv_from(&mut buf).await?;
         buf.truncate(n);
         Ok((buf, src))
     }
@@ -203,7 +204,7 @@ mod gro {
             pool: &mut PacketBufPool,
         ) -> io::Result<(Packet, SocketAddr)> {
             let mut buf = pool.get();
-            let (n, src) = self.inner.recv_from(&mut buf).await?;
+            let (n, src) = self.socket()?.recv_from(&mut buf).await?;
             buf.truncate(n);
             Ok((buf, src))
         }
@@ -214,13 +215,12 @@ mod gro {
             pool: &mut PacketBufPool,
             packets: &mut Vec<(Packet, SocketAddr)>,
         ) -> io::Result<()> {
-            let socket = self.inner.clone();
+            let socket = self.socket()?;
             recv_buf.gro_buf.resize(MAX_COALESCED_SIZE, 0);
 
-            let msg = self
-                .inner
+            let msg = socket
                 .async_io(Interest::READABLE, || {
-                    recvmsg(recv_buf.gro_buf.as_mut_slice(), &mut recv_buf.cmsg, &socket)
+                    recvmsg(recv_buf.gro_buf.as_mut_slice(), &mut recv_buf.cmsg, socket)
                 })
                 .await?;
 
@@ -254,7 +254,7 @@ mod gro {
 
         /// Enable receive offloading
         fn enable_udp_gro(&self) -> io::Result<()> {
-            let raw_sock = self.inner.as_raw_socket();
+            let raw_sock = self.socket()?.as_raw_socket();
             let val: u32 = u32::try_from(MAX_COALESCED_SIZE).unwrap();
 
             // SAFETY: We are passing valid pointers


### PR DESCRIPTION
## summary
- keep `UdpSocketFactory` usable on Linux when IPv6 UDP sockets return `EAFNOSUPPORT` or `EADDRNOTAVAIL`
- continue with an IPv4-only transport and keep the disabled IPv6 receive side pending
- add unit coverage for the error classifier and disabled IPv6 socket behavior

## tests
- `cargo fmt --check`
- `cargo clippy --locked --workspace --all-targets --all-features`
- `cargo test --locked -p gotatun udp::socket --all-features`
- `cargo test --locked --workspace`
- `cargo test --locked --workspace --no-default-features --features ring`
- `cargo test --locked --workspace --all-features`
- `cargo hack check --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/160)
<!-- Reviewable:end -->
