### PR TITLE
Harden preshared-key lifecycle with zeroizing ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "windows-sys 0.61.2",
  "x25519-dalek",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ typed-builder = "0.21.0"
 windows-sys = { version = ">=0.60, <=0.61" }
 x25519-dalek = "2.0.1"
 zerocopy = "0.8.27"
+zeroize = "1.8.2"
 
 [profile.bench]
 lto = true  # Enable full link-time optimization.

--- a/gotatun/Cargo.toml
+++ b/gotatun/Cargo.toml
@@ -71,6 +71,7 @@ x25519-dalek = { workspace = true, features = [
   "static_secrets",
 ] }
 zerocopy = { workspace = true, features = ["derive", "std"] }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -15,6 +15,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use ipnetwork::IpNetwork;
 use x25519_dalek::{PublicKey, StaticSecret};
 
+use crate::PresharedKey;
 use crate::device::Error;
 use crate::device::{Connection, Device, DeviceState, DeviceTransports, Peer, Reconfigure};
 
@@ -91,7 +92,7 @@ impl<T> From<Option<T>> for Update<T> {
 #[derive(Default)]
 #[non_exhaustive]
 pub struct PeerMut {
-    preshared_key: Update<[u8; 32]>,
+    preshared_key: Update<PresharedKey>,
     endpoint: Update<SocketAddr>,
     keepalive: Update<u16>,
 
@@ -100,8 +101,12 @@ pub struct PeerMut {
 }
 
 impl PeerMut {
-    /// Set or clear the preshared key for this peer.
-    pub fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+    /// Set or clear the preshared key used by this peer's handshakes.
+    ///
+    /// This update does not invalidate established transport sessions. An
+    /// in-flight handshake can fail if the remote peer generated a message
+    /// using the previous key.
+    pub fn set_preshared_key(&mut self, preshared_key: Option<PresharedKey>) {
         self.preshared_key = preshared_key.into();
     }
 
@@ -151,7 +156,11 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
         self.device.fwmark
     }
 
-    /// Return all peers on the device
+    /// Return all peers on the device.
+    ///
+    /// Each returned configuration owns an independent clone of its PSK. Those
+    /// clones zeroize on drop, but retaining the result also retains the copied
+    /// secret material.
     pub async fn peers(&self) -> Vec<PeerStats> {
         let mut peers = vec![];
         for (pubkey, peer) in self.device.peers.iter() {
@@ -185,7 +194,7 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
             peers.push(PeerStats {
                 peer: Peer {
                     public_key: *pubkey,
-                    preshared_key: p.tunnel.preshared_key(),
+                    preshared_key: p.tunnel.preshared_key().cloned(),
                     allowed_ips: p.allowed_ips.iter().map(|(_, net)| net).collect(),
                     endpoint: p.endpoint.addr,
                     keepalive: p.tunnel.persistent_keepalive(),
@@ -269,13 +278,19 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
     ///
     /// All fields of the peer will be overwritten. Returns `false` if no peer with this public key
     /// exists. See also [`Self::add_or_update_peer`] and [`Self::modify_peer`].
-    pub async fn update_peer(&mut self, peer: Peer) -> bool {
-        self.modify_peer(&peer.public_key, |peer_mut| {
+    pub async fn update_peer(&mut self, mut peer: Peer) -> bool {
+        let public_key = peer.public_key;
+        let allowed_ips = std::mem::take(&mut peer.allowed_ips);
+        let endpoint = peer.endpoint;
+        let keepalive = peer.keepalive;
+        let preshared_key = peer.preshared_key.take();
+
+        self.modify_peer(&public_key, |peer_mut| {
             peer_mut.clear_allowed_ips();
-            peer_mut.add_allowed_ips(peer.allowed_ips);
-            peer_mut.set_endpoint(peer.endpoint);
-            peer_mut.set_keepalive(peer.keepalive);
-            peer_mut.set_preshared_key(peer.preshared_key);
+            peer_mut.add_allowed_ips(allowed_ips);
+            peer_mut.set_endpoint(endpoint);
+            peer_mut.set_keepalive(keepalive);
+            peer_mut.set_preshared_key(preshared_key);
         })
         .await
     }

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -156,11 +156,7 @@ impl<T: DeviceTransports> DeviceRead<'_, T> {
         self.device.fwmark
     }
 
-    /// Return all peers on the device.
-    ///
-    /// Each returned configuration owns an independent clone of its PSK. Those
-    /// clones zeroize on drop, but retaining the result also retains the copied
-    /// secret material.
+    /// Return all peers on the device
     pub async fn peers(&self) -> Vec<PeerStats> {
         let mut peers = vec![];
         for (pubkey, peer) in self.device.peers.iter() {
@@ -278,19 +274,13 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
     ///
     /// All fields of the peer will be overwritten. Returns `false` if no peer with this public key
     /// exists. See also [`Self::add_or_update_peer`] and [`Self::modify_peer`].
-    pub async fn update_peer(&mut self, mut peer: Peer) -> bool {
-        let public_key = peer.public_key;
-        let allowed_ips = std::mem::take(&mut peer.allowed_ips);
-        let endpoint = peer.endpoint;
-        let keepalive = peer.keepalive;
-        let preshared_key = peer.preshared_key.take();
-
-        self.modify_peer(&public_key, |peer_mut| {
+    pub async fn update_peer(&mut self, peer: Peer) -> bool {
+        self.modify_peer(&peer.public_key, |peer_mut| {
             peer_mut.clear_allowed_ips();
-            peer_mut.add_allowed_ips(allowed_ips);
-            peer_mut.set_endpoint(endpoint);
-            peer_mut.set_keepalive(keepalive);
-            peer_mut.set_preshared_key(preshared_key);
+            peer_mut.add_allowed_ips(peer.allowed_ips);
+            peer_mut.set_endpoint(peer.endpoint);
+            peer_mut.set_keepalive(peer.keepalive);
+            peer_mut.set_preshared_key(peer.preshared_key);
         })
         .await
     }

--- a/gotatun/src/device/peer.rs
+++ b/gotatun/src/device/peer.rs
@@ -14,11 +14,14 @@ use std::net::SocketAddr;
 use ipnetwork::IpNetwork;
 use x25519_dalek::PublicKey;
 
+use crate::PresharedKey;
 #[cfg(feature = "daita")]
 use crate::device::daita::DaitaSettings;
 use crate::noise::TimerParams;
 
 /// Peer data. Used to construct and update peers in a [`Device`](crate::device::Device).
+///
+/// Cloning a peer also clones its PSK into an independent zeroizing allocation.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Peer {
@@ -32,9 +35,8 @@ pub struct Peer {
     pub endpoint: Option<SocketAddr>,
     /// List of IP networks that are allowed to be routed through this peer.
     pub allowed_ips: Vec<IpNetwork>,
-    // TODO: zeroize
     /// Optional preshared key for additional security.
-    pub preshared_key: Option<[u8; 32]>,
+    pub preshared_key: Option<PresharedKey>,
     /// Persistent keepalive interval in seconds. Disabled if `None`.
     pub keepalive: Option<u16>,
 
@@ -83,9 +85,14 @@ impl Peer {
         self
     }
 
-    /// Set the preshared key for this peer.
-    pub const fn with_preshared_key(mut self, preshared_key: [u8; 32]) -> Self {
-        self.preshared_key = Some(preshared_key);
+    /// Copy a preshared key into zeroizing storage for this peer.
+    ///
+    /// The function's local array is cleared, but `[u8; 32]` is [`Copy`], so a
+    /// copy retained by the caller is unaffected. Assign a
+    /// [`PresharedKey::take_from`] result to [`Self::preshared_key`] when the
+    /// caller's source array must also be cleared.
+    pub fn with_preshared_key(mut self, mut preshared_key: [u8; 32]) -> Self {
+        self.preshared_key = Some(PresharedKey::take_from(&mut preshared_key));
         self
     }
 

--- a/gotatun/src/device/peer.rs
+++ b/gotatun/src/device/peer.rs
@@ -20,8 +20,6 @@ use crate::device::daita::DaitaSettings;
 use crate::noise::TimerParams;
 
 /// Peer data. Used to construct and update peers in a [`Device`](crate::device::Device).
-///
-/// Cloning a peer also clones its PSK into an independent zeroizing allocation.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Peer {
@@ -85,14 +83,9 @@ impl Peer {
         self
     }
 
-    /// Copy a preshared key into zeroizing storage for this peer.
-    ///
-    /// The function's local array is cleared, but `[u8; 32]` is [`Copy`], so a
-    /// copy retained by the caller is unaffected. Assign a
-    /// [`PresharedKey::take_from`] result to [`Self::preshared_key`] when the
-    /// caller's source array must also be cleared.
-    pub fn with_preshared_key(mut self, mut preshared_key: [u8; 32]) -> Self {
-        self.preshared_key = Some(PresharedKey::take_from(&mut preshared_key));
+    /// Set the preshared key for this peer.
+    pub fn with_preshared_key(mut self, preshared_key: impl Into<PresharedKey>) -> Self {
+        self.preshared_key = Some(preshared_key.into());
         self
     }
 

--- a/gotatun/src/device/peer_state.rs
+++ b/gotatun/src/device/peer_state.rs
@@ -14,6 +14,7 @@ use ipnetwork::IpNetwork;
 
 use std::net::SocketAddr;
 
+use crate::PresharedKey;
 use crate::device::AllowedIps;
 #[cfg(feature = "daita")]
 use crate::device::daita::{DaitaHooks, DaitaSettings};
@@ -125,7 +126,7 @@ impl PeerState {
         self.tunnel.persistent_keepalive()
     }
 
-    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+    pub fn preshared_key(&self) -> Option<&PresharedKey> {
         self.tunnel.preshared_key()
     }
 }

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -241,7 +241,7 @@ async fn modify_peer_preshared_key_reaches_tunnel() {
         let updated = device
             .device
             .modify_peer(&peer.public_key, |peer_mut| {
-                peer_mut.set_preshared_key(Some(preshared_key));
+                peer_mut.set_preshared_key(Some(preshared_key.into()));
             })
             .await
             .expect("modify_peer should succeed");
@@ -257,7 +257,35 @@ async fn modify_peer_preshared_key_reaches_tunnel() {
 async fn update_peer_preshared_key_reaches_tunnel() {
     assert_peer_psk_update_reaches_tunnel(async |device: &mut mock::MockDevice, preshared_key| {
         let mut peer = get_first_and_only_peer(device).await;
-        peer.preshared_key = Some(preshared_key);
+        peer.preshared_key = Some(preshared_key.into());
+        let updated = device
+            .device
+            .update_peer(peer)
+            .await
+            .expect("update_peer should succeed");
+        assert!(updated, "peer update should affect an existing peer");
+        advance_mock_clock();
+    })
+    .await;
+}
+
+/// Ensures clearing a peer's preshared key via Device::modify_peer propagates into its noise state.
+#[tokio::test]
+#[test_log::test]
+async fn modify_peer_clear_preshared_key_reaches_tunnel() {
+    assert_peer_psk_clear_reaches_tunnel(async |device: &mut mock::MockDevice| {
+        set_first_peer_preshared_key(device, None).await;
+    })
+    .await;
+}
+
+/// Ensures clearing a peer's preshared key via Device::update_peer propagates into its noise state.
+#[tokio::test]
+#[test_log::test]
+async fn update_peer_clear_preshared_key_reaches_tunnel() {
+    assert_peer_psk_clear_reaches_tunnel(async |device: &mut mock::MockDevice| {
+        let mut peer = get_first_and_only_peer(device).await;
+        peer.preshared_key = None;
         let updated = device
             .device
             .update_peer(peer)
@@ -305,6 +333,61 @@ async fn assert_peer_psk_update_reaches_tunnel(
         set_preshared_key(&mut alice, preshared_key).await;
         send_and_expect_delivery(&alice, &mut bob, &packet).await;
     }
+}
+
+/// Clearing a peer's preshared key must propagate into its noise state, and must
+/// not tear down a live session. `clear_preshared_key` applies the change through
+/// one of the device's configuration APIs.
+async fn assert_peer_psk_clear_reaches_tunnel(
+    clear_preshared_key: impl AsyncFn(&mut mock::MockDevice),
+) {
+    let packet = mock::packet(b"Hello!");
+    let preshared_key = [0xA5; 32];
+
+    // One side clears its PSK: the peers disagree and the next handshake fails.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        set_first_peer_preshared_key(&mut alice, Some(preshared_key)).await;
+        set_first_peer_preshared_key(&mut bob, Some(preshared_key)).await;
+        clear_preshared_key(&mut alice).await;
+        send_and_expect_blocked(&alice, &mut bob, &packet).await;
+    }
+
+    // Both sides clear the PSK: traffic flows again.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        set_first_peer_preshared_key(&mut alice, Some(preshared_key)).await;
+        set_first_peer_preshared_key(&mut bob, Some(preshared_key)).await;
+        clear_preshared_key(&mut alice).await;
+        clear_preshared_key(&mut bob).await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+    }
+
+    // Clearing one side after a session is established keeps the live session working.
+    {
+        let (mut alice, mut bob, _eve) = mock::device_pair().await;
+        set_first_peer_preshared_key(&mut alice, Some(preshared_key)).await;
+        set_first_peer_preshared_key(&mut bob, Some(preshared_key)).await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+        clear_preshared_key(&mut alice).await;
+        send_and_expect_delivery(&alice, &mut bob, &packet).await;
+    }
+}
+
+async fn set_first_peer_preshared_key(
+    device: &mut mock::MockDevice,
+    preshared_key: Option<[u8; 32]>,
+) {
+    let peer = get_first_and_only_peer(device).await;
+    let updated = device
+        .device
+        .modify_peer(&peer.public_key, |peer_mut| {
+            peer_mut.set_preshared_key(preshared_key.map(Into::into));
+        })
+        .await
+        .expect("modify_peer should succeed");
+    assert!(updated, "peer update should affect an existing peer");
+    advance_mock_clock();
 }
 
 /// Return the device's single configured peer, asserting there is exactly one.

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -502,7 +502,7 @@ async fn on_api_get(_: Get, d: &DeviceState<impl DeviceTransports>) -> GetRespon
                 public_key: KeyBytes(*public_key.as_bytes()),
                 preshared_key: peer
                     .preshared_key()
-                    .map(|key| command::SetUnset::Set(KeyBytes(key))),
+                    .map(|key| command::SetUnset::Set(KeyBytes(*key.as_bytes()))),
                 endpoint,
                 persistent_keepalive_interval: peer.persistent_keepalive(),
                 allowed_ip: peer.allowed_ips().collect(),
@@ -643,7 +643,13 @@ async fn on_api_set(
 
                 crate::device::Peer {
                     public_key,
-                    preshared_key: peer.preshared_key(),
+                    // Preserve the old PSK only when the request omitted this
+                    // field; avoid cloning a secret that will be replaced.
+                    preshared_key: if preshared_key.is_none() {
+                        peer.preshared_key().cloned()
+                    } else {
+                        None
+                    },
                     endpoint: peer.endpoint().addr,
                     keepalive: peer.persistent_keepalive(),
                     allowed_ips: if replace_allowed_ips {
@@ -669,7 +675,7 @@ async fn on_api_set(
 
         match preshared_key {
             Some(command::SetUnset::Set(psk)) => {
-                new_peer.preshared_key = Some(psk.0);
+                new_peer.preshared_key = Some(psk.0.into());
             }
             Some(command::SetUnset::Unset) => {
                 new_peer.preshared_key = None;

--- a/gotatun/src/lib.rs
+++ b/gotatun/src/lib.rs
@@ -24,10 +24,13 @@ mod crypto;
 pub mod device;
 pub mod noise;
 pub mod packet;
+mod secret;
 pub mod tun;
 pub mod udp;
 
 mod task;
+
+pub use secret::PresharedKey;
 
 #[cfg(not(feature = "mock_instant"))]
 pub(crate) mod sleepyinstant;

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::PresharedKey;
 use crate::crypto::aead::{Aad, CHACHA20_POLY1305, LessSafeKey, Nonce, UnboundKey};
 use crate::noise::errors::WireGuardError;
 use crate::noise::index_table::{Index, IndexTable};
@@ -34,6 +35,8 @@ pub(crate) const LABEL_MAC1: &[u8; 8] = b"mac1----";
 pub(crate) const LABEL_COOKIE: &[u8; 8] = b"cookie--";
 const KEY_LEN: usize = 32;
 const TIMESTAMP_LEN: usize = 12;
+// WireGuard represents an absent optional PSK by mixing 32 zero bytes.
+const ZERO_PRESHARED_KEY: [u8; KEY_LEN] = [0u8; KEY_LEN];
 
 // initiator.chaining_key = HASH(CONSTRUCTION)
 const INITIAL_CHAIN_KEY: [u8; KEY_LEN] = [
@@ -252,7 +255,7 @@ struct NoiseParams {
     /// A pre-computation of HASH("mac1----", `peer_static_public`) for this peer
     sending_mac1_key: [u8; KEY_LEN],
     /// An optional preshared key
-    preshared_key: Option<[u8; KEY_LEN]>,
+    preshared_key: Option<PresharedKey>,
 }
 
 impl std::fmt::Debug for NoiseParams {
@@ -263,7 +266,10 @@ impl std::fmt::Debug for NoiseParams {
             .field("peer_static_public", &self.peer_static_public)
             .field("static_shared", &"<redacted>")
             .field("sending_mac1_key", &self.sending_mac1_key)
-            .field("preshared_key", &self.preshared_key)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "<redacted>"),
+            )
             .finish()
     }
 }
@@ -403,7 +409,7 @@ impl NoiseParams {
         static_private: x25519::StaticSecret,
         static_public: x25519::PublicKey,
         peer_static_public: x25519::PublicKey,
-        preshared_key: Option<[u8; 32]>,
+        preshared_key: Option<PresharedKey>,
     ) -> NoiseParams {
         let static_shared = static_private.diffie_hellman(&peer_static_public);
 
@@ -435,8 +441,19 @@ impl NoiseParams {
         self.static_shared = self.static_private.diffie_hellman(&self.peer_static_public);
     }
 
-    fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+    fn set_preshared_key(&mut self, preshared_key: Option<PresharedKey>) {
         self.preshared_key = preshared_key;
+    }
+
+    fn preshared_key(&self) -> Option<&PresharedKey> {
+        self.preshared_key.as_ref()
+    }
+
+    fn preshared_key_bytes(&self) -> &[u8; KEY_LEN] {
+        self.preshared_key
+            .as_ref()
+            .map(PresharedKey::as_bytes)
+            .unwrap_or(&ZERO_PRESHARED_KEY)
     }
 }
 
@@ -446,7 +463,7 @@ impl Handshake {
         static_public: x25519::PublicKey,
         peer_static_public: x25519::PublicKey,
         index_table: IndexTable,
-        preshared_key: Option<[u8; 32]>,
+        preshared_key: Option<PresharedKey>,
     ) -> Handshake {
         let params = NoiseParams::new(
             static_private,
@@ -512,16 +529,17 @@ impl Handshake {
         self.previous = HandshakeState::None;
     }
 
-    /// Store the preshared key used by future handshakes.
+    /// Store the preshared key used when a handshake next reaches PSK mixing.
     ///
-    /// Any in-flight handshake and established sessions are deliberately left untouched.
-    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+    /// Established transport sessions are left untouched. An in-flight
+    /// handshake can fail if its peer generated a message using the old key.
+    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<PresharedKey>) {
         self.params.set_preshared_key(preshared_key);
     }
 
-    /// Get the preshared key
-    pub(crate) fn preshared_key(&self) -> Option<[u8; 32]> {
-        self.params.preshared_key
+    /// Borrow the configured preshared key without creating another secret copy.
+    pub(crate) fn preshared_key(&self) -> Option<&PresharedKey> {
+        self.params.preshared_key()
     }
 
     pub(super) fn receive_handshake_initialization(
@@ -649,10 +667,7 @@ impl Handshake {
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, preshared_key)
-        let temp = b2s_hmac(
-            &chaining_key,
-            &self.params.preshared_key.unwrap_or([0u8; 32])[..],
-        );
+        let temp = b2s_hmac(&chaining_key, self.params.preshared_key_bytes());
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp2 = HMAC(temp, responder.chaining_key || 0x2)
@@ -891,10 +906,7 @@ impl Handshake {
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp = HMAC(responder.chaining_key, preshared_key)
-        let temp = b2s_hmac(
-            &chaining_key,
-            &self.params.preshared_key.unwrap_or([0u8; 32])[..],
-        );
+        let temp = b2s_hmac(&chaining_key, self.params.preshared_key_bytes());
         // responder.chaining_key = HMAC(temp, 0x1)
         chaining_key = b2s_hmac(&temp, &[0x01]);
         // temp2 = HMAC(temp, responder.chaining_key || 0x2)

--- a/gotatun/src/noise/handshake.rs
+++ b/gotatun/src/noise/handshake.rs
@@ -537,7 +537,7 @@ impl Handshake {
         self.params.set_preshared_key(preshared_key);
     }
 
-    /// Borrow the configured preshared key without creating another secret copy.
+    /// Borrow the configured preshared key.
     pub(crate) fn preshared_key(&self) -> Option<&PresharedKey> {
         self.params.preshared_key()
     }

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -27,6 +27,7 @@ mod timers;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use zerocopy::IntoBytes;
 
+use crate::PresharedKey;
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::Handshake;
 use crate::noise::index_table::IndexTable;
@@ -93,7 +94,7 @@ impl Tunn<StdRng> {
     pub fn new(
         static_private: x25519::StaticSecret,
         peer_static_public: x25519::PublicKey,
-        preshared_key: Option<[u8; 32]>,
+        preshared_key: Option<PresharedKey>,
         persistent_keepalive: Option<u16>,
         index_table: IndexTable,
         rate_limiter: Arc<RateLimiter>,
@@ -115,7 +116,7 @@ impl<R: RngCore + Send> Tunn<R> {
     pub fn new_with_rng(
         static_private: x25519::StaticSecret,
         peer_static_public: x25519::PublicKey,
-        preshared_key: Option<[u8; 32]>,
+        preshared_key: Option<PresharedKey>,
         persistent_keepalive: Option<u16>,
         index_table: IndexTable,
         rate_limiter: Arc<RateLimiter>,
@@ -175,19 +176,20 @@ impl<R: RngCore + Send> Tunn<R> {
         }
     }
 
-    /// Update the preshared key used for future handshakes.
+    /// Replace the preshared key used when a handshake next reaches PSK mixing.
     ///
-    /// The new key is only mixed in by subsequent handshakes. The current
-    /// session therefore keeps working until it is rekeyed, so changing
-    /// the key does not interrupt traffic.
-    // Not invalidating current sessions matches the Linux kernel, which update
-    // the key in place and never tear down the session on a configuration change.
-    pub fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+    /// `None` selects WireGuard's all-zero no-PSK input. This method does not
+    /// invalidate established transport sessions. An in-flight handshake reads
+    /// the configured key when it reaches PSK mixing and can fail if its peer
+    /// generated a message using the previous key.
+    // This matches the Linux kernel's in-place update behavior: established
+    // sessions are not torn down by a PSK configuration change.
+    pub fn set_preshared_key(&mut self, preshared_key: Option<PresharedKey>) {
         self.handshake.set_preshared_key(preshared_key);
     }
 
-    /// Get the current preshared key.
-    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+    /// Borrow the current preshared key without creating another secret copy.
+    pub fn preshared_key(&self) -> Option<&PresharedKey> {
         self.handshake.preshared_key()
     }
 
@@ -878,19 +880,17 @@ mod tests {
         assert_packet_roundtrip(&mut my_tun, &mut their_tun);
     }
 
-    /// Changing the preshared key only affects the next session, never the
-    /// current one. The PSK is not part of the established session's transport
-    /// keys, so traffic keeps flowing even though `their_tun` never learned the
-    /// new key. The next handshake does mix it in, so a one-sided change makes
-    /// the rekey fail to authenticate.
+    /// Changing the PSK does not alter the keys of an already established
+    /// transport session. A subsequent rekey uses the newly configured PSK, so
+    /// a one-sided change makes that handshake fail to authenticate.
     #[test]
-    fn set_preshared_key_only_affects_next_session() {
+    fn set_preshared_key_does_not_invalidate_established_session() {
         let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
 
         // Only one side adopts a new key.
-        my_tun.set_preshared_key(Some([7; 32]));
+        my_tun.set_preshared_key(Some([7; 32].into()));
 
-        // The established session is unaffected and keeps working.
+        // The PSK update did not invalidate this established session.
         assert_packet_roundtrip(&mut my_tun, &mut their_tun);
 
         // A second handshake needs a strictly newer timestamp than the first.
@@ -902,6 +902,30 @@ mod tests {
         assert!(
             matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
             "expected the rekey to fail on the diverged PSK, got {result:?}"
+        );
+
+        // A failed rekey does not discard the established transport session.
+        assert_packet_roundtrip(&mut my_tun, &mut their_tun);
+    }
+
+    /// Updating the PSK takes effect immediately for an in-flight initiator
+    /// when it later processes the response's PSK mixing step.
+    #[test]
+    fn set_preshared_key_affects_in_flight_handshake() {
+        let (mut my_tun, mut their_tun) = create_two_tuns();
+        my_tun.set_preshared_key(Some([7; 32].into()));
+        their_tun.set_preshared_key(Some([7; 32].into()));
+
+        let init = create_handshake_init(&mut my_tun);
+        let response = create_handshake_response(&mut their_tun, init);
+
+        // The response was generated with the old PSK, but the initiator uses
+        // the newly configured PSK when it processes that response.
+        my_tun.set_preshared_key(Some([4; 32].into()));
+        let result = my_tun.handle_incoming_packet(WgKind::HandshakeResp(response));
+        assert!(
+            matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
+            "expected the in-flight handshake to fail after PSK rotation, got {result:?}"
         );
     }
 
@@ -921,8 +945,8 @@ mod tests {
     #[test]
     fn handshake_completes_with_matching_preshared_key() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        my_tun.set_preshared_key(Some([7; 32]));
-        their_tun.set_preshared_key(Some([7; 32]));
+        my_tun.set_preshared_key(Some([7; 32].into()));
+        their_tun.set_preshared_key(Some([7; 32].into()));
         complete_handshake(&mut my_tun, &mut their_tun);
     }
 
@@ -930,7 +954,7 @@ mod tests {
     #[test]
     fn handshake_fails_with_one_sided_preshared_key() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        my_tun.set_preshared_key(Some([7; 32]));
+        my_tun.set_preshared_key(Some([7; 32].into()));
         let result = try_handshake(&mut my_tun, &mut their_tun);
         assert!(
             matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),
@@ -942,8 +966,8 @@ mod tests {
     #[test]
     fn handshake_fails_with_different_preshared_key() {
         let (mut my_tun, mut their_tun) = create_two_tuns();
-        my_tun.set_preshared_key(Some([7; 32]));
-        their_tun.set_preshared_key(Some([4; 32]));
+        my_tun.set_preshared_key(Some([7; 32].into()));
+        their_tun.set_preshared_key(Some([4; 32].into()));
         let result = try_handshake(&mut my_tun, &mut their_tun);
         assert!(
             matches!(result, TunnResult::Err(WireGuardError::InvalidAeadTag)),

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -188,7 +188,7 @@ impl<R: RngCore + Send> Tunn<R> {
         self.handshake.set_preshared_key(preshared_key);
     }
 
-    /// Borrow the current preshared key without creating another secret copy.
+    /// Borrow the current preshared key.
     pub fn preshared_key(&self) -> Option<&PresharedKey> {
         self.handshake.preshared_key()
     }

--- a/gotatun/src/secret.rs
+++ b/gotatun/src/secret.rs
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright (c) Mullvad VPN AB. All rights reserved.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::fmt;
+
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+/// Fixed-size secret storage kept behind a stable heap allocation, so moving
+/// an owner moves only the pointer rather than copying the key bytes. The outer
+/// drop clears eagerly and `Zeroizing` remains the final drop guard.
+pub(crate) struct SecretBytes32(Box<Zeroizing<[u8; 32]>>);
+
+impl SecretBytes32 {
+    pub(crate) fn from_bytes_ref(bytes: &[u8; 32]) -> Self {
+        let mut secret = Self::zeroed();
+        secret.0.as_mut().copy_from_slice(bytes);
+        secret
+    }
+
+    pub(crate) fn take_from(bytes: &mut [u8; 32]) -> Self {
+        let secret = Self::from_bytes_ref(bytes);
+        bytes.zeroize();
+        secret
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+
+    fn zeroed() -> Self {
+        Self(Box::new(Zeroizing::new([0u8; 32])))
+    }
+
+    fn zeroize(&mut self) {
+        self.0.as_mut().zeroize();
+    }
+}
+
+impl Clone for SecretBytes32 {
+    fn clone(&self) -> Self {
+        Self::from_bytes_ref(self.as_bytes())
+    }
+}
+
+impl Drop for SecretBytes32 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SecretBytes32 {}
+
+/// WireGuard preshared key material.
+///
+/// This type owns PSK bytes as secret material: it is non-`Copy`, redacts
+/// `Debug`, and zeroizes its backing storage on drop. Raw byte arrays should
+/// only be used at explicit import/export boundaries or borrowed for crypto.
+/// Cloning creates an independent zeroizing allocation; replacing or dropping
+/// one value does not revoke any clones. Caller-owned buffers, compiler-created
+/// temporaries, registers, and allocator history are outside this guarantee.
+pub struct PresharedKey(SecretBytes32);
+
+impl PresharedKey {
+    /// Copy raw PSK bytes into a secret-owning value.
+    ///
+    /// This clears the function's local input after importing it, but arrays
+    /// are [`Copy`]. Any copy retained by the caller is unaffected. Use
+    /// [`Self::take_from`] to clear a mutable source array while importing it.
+    pub fn new(mut bytes: [u8; 32]) -> Self {
+        Self::take_from(&mut bytes)
+    }
+
+    /// Import raw PSK bytes and zeroize the source array.
+    ///
+    /// This covers the supplied array, but not copies retained elsewhere or
+    /// compiler-generated temporaries.
+    pub fn take_from(bytes: &mut [u8; 32]) -> Self {
+        Self(SecretBytes32::take_from(bytes))
+    }
+
+    /// Copy borrowed raw PSK bytes into a secret-owning value.
+    ///
+    /// The source is not cleared. The borrowed bytes are secret material and
+    /// should only be exposed at an explicit import/export or cryptographic
+    /// boundary.
+    pub fn from_bytes_ref(bytes: &[u8; 32]) -> Self {
+        Self(SecretBytes32::from_bytes_ref(bytes))
+    }
+
+    /// Borrow the PSK bytes for cryptographic use.
+    ///
+    /// The returned bytes are secret material. Do not store, log, or copy them
+    /// unless crossing an explicit export or cryptographic boundary.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+impl Clone for PresharedKey {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl fmt::Debug for PresharedKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PresharedKey").field(&"<redacted>").finish()
+    }
+}
+
+impl ZeroizeOnDrop for PresharedKey {}
+
+impl From<[u8; 32]> for PresharedKey {
+    fn from(mut bytes: [u8; 32]) -> Self {
+        Self::take_from(&mut bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zeroize::ZeroizeOnDrop;
+
+    use super::PresharedKey;
+
+    fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+    #[test]
+    fn implements_zeroize_on_drop() {
+        assert_zeroize_on_drop::<PresharedKey>();
+    }
+
+    #[test]
+    fn take_from_clears_source() {
+        let mut source = [0xA5; 32];
+        let key = PresharedKey::take_from(&mut source);
+
+        assert_eq!(source, [0; 32]);
+        assert_eq!(key.as_bytes(), &[0xA5; 32]);
+    }
+
+    #[test]
+    fn clone_uses_independent_storage() {
+        let key = PresharedKey::new([0xA5; 32]);
+        let clone = key.clone();
+
+        assert_eq!(clone.as_bytes(), key.as_bytes());
+        assert_ne!(clone.as_bytes().as_ptr(), key.as_bytes().as_ptr());
+    }
+
+    #[test]
+    fn debug_redacts_preshared_key() {
+        let key = PresharedKey::new([0xA5; 32]);
+        let debug = format!("{key:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("165"), "PSK Debug must not print raw bytes");
+    }
+}

--- a/gotatun/src/secret.rs
+++ b/gotatun/src/secret.rs
@@ -10,18 +10,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::fmt;
+use std::sync::Arc;
 
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, Zeroizing};
 
 /// Fixed-size secret storage kept behind a stable heap allocation, so moving
-/// an owner moves only the pointer rather than copying the key bytes. The outer
-/// drop clears eagerly and `Zeroizing` remains the final drop guard.
-pub(crate) struct SecretBytes32(Box<Zeroizing<[u8; 32]>>);
+/// or cloning an owner does not copy the key bytes.
+#[derive(Clone)]
+pub(crate) struct SecretBytes32(Arc<Zeroizing<[u8; 32]>>);
 
 impl SecretBytes32 {
     pub(crate) fn from_bytes_ref(bytes: &[u8; 32]) -> Self {
         let mut secret = Self::zeroed();
-        secret.0.as_mut().copy_from_slice(bytes);
+        Arc::get_mut(&mut secret.0)
+            .expect("new secret is not shared")
+            .copy_from_slice(bytes);
         secret
     }
 
@@ -36,36 +39,20 @@ impl SecretBytes32 {
     }
 
     fn zeroed() -> Self {
-        Self(Box::new(Zeroizing::new([0u8; 32])))
-    }
-
-    fn zeroize(&mut self) {
-        self.0.as_mut().zeroize();
+        Self(Arc::new(Zeroizing::new([0u8; 32])))
     }
 }
-
-impl Clone for SecretBytes32 {
-    fn clone(&self) -> Self {
-        Self::from_bytes_ref(self.as_bytes())
-    }
-}
-
-impl Drop for SecretBytes32 {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl ZeroizeOnDrop for SecretBytes32 {}
 
 /// WireGuard preshared key material.
 ///
 /// This type owns PSK bytes as secret material: it is non-`Copy`, redacts
-/// `Debug`, and zeroizes its backing storage on drop. Raw byte arrays should
-/// only be used at explicit import/export boundaries or borrowed for crypto.
-/// Cloning creates an independent zeroizing allocation; replacing or dropping
-/// one value does not revoke any clones. Caller-owned buffers, compiler-created
-/// temporaries, registers, and allocator history are outside this guarantee.
+/// `Debug`, and shares its backing storage when cloned. The storage is zeroized
+/// when the last owner is dropped; replacing or dropping one value does not
+/// revoke other clones. Raw byte arrays should only be used at explicit
+/// import/export boundaries or borrowed for crypto. Caller-owned buffers,
+/// compiler-created temporaries, registers, and allocator history are outside
+/// this guarantee.
+#[derive(Clone)]
 pub struct PresharedKey(SecretBytes32);
 
 impl PresharedKey {
@@ -104,19 +91,11 @@ impl PresharedKey {
     }
 }
 
-impl Clone for PresharedKey {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
 impl fmt::Debug for PresharedKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("PresharedKey").field(&"<redacted>").finish()
     }
 }
-
-impl ZeroizeOnDrop for PresharedKey {}
 
 impl From<[u8; 32]> for PresharedKey {
     fn from(mut bytes: [u8; 32]) -> Self {
@@ -126,16 +105,7 @@ impl From<[u8; 32]> for PresharedKey {
 
 #[cfg(test)]
 mod tests {
-    use zeroize::ZeroizeOnDrop;
-
     use super::PresharedKey;
-
-    fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
-
-    #[test]
-    fn implements_zeroize_on_drop() {
-        assert_zeroize_on_drop::<PresharedKey>();
-    }
 
     #[test]
     fn take_from_clears_source() {
@@ -147,12 +117,15 @@ mod tests {
     }
 
     #[test]
-    fn clone_uses_independent_storage() {
+    fn clone_shares_storage() {
         let key = PresharedKey::new([0xA5; 32]);
         let clone = key.clone();
 
         assert_eq!(clone.as_bytes(), key.as_bytes());
-        assert_ne!(clone.as_bytes().as_ptr(), key.as_bytes().as_ptr());
+        assert_eq!(clone.as_bytes().as_ptr(), key.as_bytes().as_ptr());
+
+        drop(key);
+        assert_eq!(clone.as_bytes(), &[0xA5; 32]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #163

## Summary

Core peer and Noise state store preshared keys as `Copy` arrays, allowing implicit key copies and leaving retired storage uncleared. Introduce a public, non-`Copy` `PresharedKey` with redacted `Debug` and shared zeroizing heap storage.

Clones share the same `Arc<Zeroizing<[u8; 32]>>` allocation. The inner `Zeroizing` clears the bytes when the last owner is dropped. Replacing or clearing one handle leaves any surviving clones usable.

## Changes

- Use `PresharedKey` for long-lived PSKs in `Peer`, `PeerMut`, `Tunn`, `Handshake`, and `NoiseParams`.
- Derive `Clone` for both secret wrappers and let `Arc` and `Zeroizing` manage the shared lifetime and final clearing, without a custom `Drop` or outer `ZeroizeOnDrop` marker.
- Allocate zeroed storage before importing key bytes. Provide by-value, borrowed, mutable source-clearing, and raw-borrow APIs.
- Move ownership through configuration updates; owned peer snapshots clone the shared handle. Keep `update_peer`'s original field-by-field update body.
- Accept `impl Into<PresharedKey>` in `Peer::with_preshared_key`, supporting both raw arrays and existing key values.
- Borrow configured key bytes at Noise PSK-mixing sites. `None` keeps WireGuard's all-zero no-PSK input.
- Limit UAPI edits to conversions required by the core type change: import existing `KeyBytes`, copy borrowed bytes into the existing response representation, and clone a handle when an omitted PSK field must preserve the existing key.

## Public API changes

This is an intentional pre-1.0 SemVer-relevant API change:

- `Peer::preshared_key` becomes `Option<PresharedKey>`.
- `PeerMut::set_preshared_key`, `Tunn::set_preshared_key`, `Tunn::new`, and `Tunn::new_with_rng` accept `Option<PresharedKey>`.
- `Tunn::preshared_key` returns `Option<&PresharedKey>`; use `.cloned()` to obtain another shared owner.
- `Peer::with_preshared_key` accepts `impl Into<PresharedKey>`. Array calls remain supported, but the method is no longer `const` because importing raw bytes allocates.

Example migration:

```rust
use gotatun::PresharedKey;

let mut raw_psk = [0xA5; 32];
let peer = peer.with_preshared_key(PresharedKey::take_from(&mut raw_psk));

if let Some(psk) = tunnel.preshared_key() {
    use_psk(psk.as_bytes());
}
```

## Runtime behavior and zeroization boundary

Matching PSKs complete a handshake; one-sided or different PSKs fail authentication. Direct updates through `Tunn::set_preshared_key` and the device `modify_peer` / `update_peer` APIs preserve established transport sessions. An in-flight handshake reads the configured key at the PSK-mixing step, so it can fail if the peer generated the corresponding message with the previous key.

The existing UAPI configuration path removes and re-adds the peer. This PR preserves that behavior; the established-session guarantee above applies to the direct update APIs, not to UAPI peer reconstruction.

Moving or cloning a `PresharedKey` does not copy its backing array. Shared storage is cleared only after the final owner is dropped, and `PresharedKey::take_from` also clears the exact mutable source array supplied by the caller. By-value and borrowed imports cannot clear copies retained by the caller.

This is best-effort memory-lifetime hardening. It does not guarantee erasure of caller-created copies, compiler temporaries, registers, allocator history, swap, core dumps, kernel buffers, or existing UAPI buffers. It does not use `mlock` or protect live secrets against arbitrary process-memory reads. Clearing requires destructors to run.

## Validation

Tests cover shared clone storage and a clone remaining usable after the original is dropped, mutable source clearing, redacted `Debug`, matching and mismatching handshakes, PSK replacement during handshakes and established sessions, and setting/clearing PSKs through both device update APIs.

Passed locally on Linux with Rust 1.95.0 at commit `0cb159b9632dfc874d89fc86d653b396a42da21a`:

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo check --locked --workspace --no-default-features --features ring`
- `cargo check --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p gotatun --all-features --no-deps`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=env cargo test --locked -p gotatun --lib --all-features`: 91 passed, 7 ignored, no failures or filtered tests.
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=env cargo test --locked -p gotatun --lib --no-default-features --features ring,device,tun`: 77 passed, 7 ignored, no failures or filtered tests.
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=env cargo test --locked -p gotatun --doc --all-features`: 8 passed, 1 ignored, no failures.
- A separate public-API smoke check compiled and ran with both array and `PresharedKey` builder arguments, including source clearing and preservation of shared storage.
- `git diff --check`

The seven privileged WireGuard integration tests and one ignored documentation example were not run. Cross-platform/Android CI, the `cargo hack` feature powerset, and `cargo-semver-checks` were not run locally. No version bump or compatibility-check suppression is included; CI results and release compatibility remain for maintainer review.

## Scope

No changes to handshake algorithms, UAPI peer reconstruction, UAPI parsing/framing/logging, `KeyBytes` ownership, or unrelated session and derived keys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/164)
<!-- Reviewable:end -->
