### PR TITLE
Exit when TUN read fails due to `ERROR_HANDLE_EOF` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+#### Windows
+- Exit when TUN read fails due to `ERROR_HANDLE_EOF`.
 
 
 ## [0.8.0] - 2026-07-09

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -211,6 +211,11 @@ fn is_fatal_tun_error(err: &io::Error) -> bool {
         return true;
     }
 
+    #[cfg(windows)]
+    if err.raw_os_error() == Some(windows_sys::Win32::Foundation::ERROR_HANDLE_EOF as i32) {
+        return true;
+    }
+
     matches!(
         err.kind(),
         io::ErrorKind::NotFound


### PR DESCRIPTION
Apparently, this is not covered by `UnexpectedEof`. :shrug: 

```
[2026-07-12 23:38:51.301] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
[2026-07-12 23:38:51.302] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
[2026-07-12 23:38:51.303] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
[2026-07-12 23:38:51.304] ERROR gotatun::tun::buffer: Error receiving IP packet: Reached the end of the file. (os error 38)
...
```

`WintunReceivePacket` [can fail](https://github.com/WireGuard/wintun/blob/ec0a6b98456fe1ba52567bb2add4bbf5f64315a1/api/wintun.h#L216-L218) due to `ERROR_HANDLE_EOF`, `ERROR_INVALID_DATA`, or `ERROR_NO_MORE_ITEMS`. `ERROR_NO_MORE_ITEMS` is simply returned when there's no packet to receive, and `ERROR_HANDLE_EOF` is returned when the device is terminating. It's a bit unclear when `ERROR_INVALID_DATA` might occur in practice and whether it's fatal.

Fix DES-3138

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/166)
<!-- Reviewable:end -->
