### PR TITLE
Make `UdpSocket::socket` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Make the `UdpSocket::socket` method public, exposing the inner `tokio::net::UdpSocket`.
+
 ### Fixed
 #### Windows
 - Exit when TUN read fails due to `ERROR_HANDLE_EOF`.

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -176,8 +176,12 @@ impl UdpSocket {
         matches!(&self.inner, UdpSocketInner::DisabledIpv6)
     }
 
+    /// Get the inner [`tokio::net::UdpSocket`].
+    ///
+    /// # Linux
+    /// Returns an error if the socket type is of IPv6 and that is disabled on the system.
     #[inline(always)]
-    pub(crate) fn socket(&self) -> io::Result<&tokio::net::UdpSocket> {
+    pub fn socket(&self) -> io::Result<&tokio::net::UdpSocket> {
         match &self.inner {
             UdpSocketInner::Socket(socket) => Ok(socket),
             #[cfg(target_os = "linux")]


### PR DESCRIPTION
Android depended on accessing the inner socket file descriptor, which broke when we removed the `AsFd` impl.

Make the inner socket accessor public, so that one can call `as_fd` on it instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/167)
<!-- Reviewable:end -->
