### PR TITLE
Reuse packet buffer when prepending data packet type

### DIFF
--- a/gotatun/src/noise/session.rs
+++ b/gotatun/src/noise/session.rs
@@ -16,7 +16,7 @@ use crate::{
     noise::index_table::Index,
     packet::{Packet, WgData, WgDataHeader, WgKind},
 };
-use bytes::{Buf, BytesMut};
+use bytes::Buf;
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use zerocopy::FromBytes;
@@ -234,12 +234,7 @@ impl Session {
         }
         let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed);
 
-        let len = WgData::OVERHEAD + packet.len();
-
-        // Prepare a buffer to hold our the WgData packet and our encapsulated payload.
-        // TODO: we can remove this allocation by pre-allocating some extra
-        // space at the beginning of `packet`s allocation, and using that.
-        let mut buf = Packet::from_bytes(BytesMut::zeroed(len));
+        let mut buf = packet.prepend_and_append_space(WgDataHeader::LEN, WgData::TAG_LEN);
 
         let data = WgData::mut_from_bytes(buf.buf_mut())
             .expect("buffer size is at least WgData::OVERHEAD");
@@ -248,11 +243,6 @@ impl Session {
         data.header = WgDataHeader::new()
             .with_receiver_idx(self.sending_index)
             .with_counter(sending_key_counter);
-
-        // Copy inner packet into place.
-        debug_assert_eq!(packet.len(), data.encrypted_encapsulated_packet_mut().len());
-        data.encrypted_encapsulated_packet_mut()
-            .copy_from_slice(&packet);
 
         let mut nonce = [0u8; 12];
         nonce[4..12].copy_from_slice(&sending_key_counter.to_le_bytes());
@@ -343,7 +333,7 @@ mod tests {
     /// Craft a (cryptographically invalid) `WgData` packet with a chosen receiver index and
     /// counter, for exercising the receive-path checks that run before decryption.
     fn make_data_packet(receiver_idx: u32, counter: u64) -> Packet<WgData> {
-        let mut buf = Packet::from_bytes(BytesMut::zeroed(WgData::OVERHEAD));
+        let mut buf = Packet::from_bytes(bytes::BytesMut::zeroed(WgData::OVERHEAD));
         let data = WgData::mut_from_bytes(buf.buf_mut()).expect("buffer is WgData::OVERHEAD");
         data.header = WgDataHeader::new()
             .with_receiver_idx(receiver_idx)
@@ -352,6 +342,73 @@ mod tests {
             unreachable!("is a wireguard data packet");
         };
         packet
+    }
+
+    fn linked_sessions() -> (Session, Session) {
+        let table: IndexTable = IndexTable::from_os_rng();
+        let alice_receiving_index = table.new_index();
+        let bob_receiving_index = table.new_index();
+
+        let alice_to_bob_key = [1u8; 32];
+        let bob_to_alice_key = [2u8; 32];
+        let alice = Session::new(
+            alice_receiving_index,
+            bob_receiving_index.value(),
+            bob_to_alice_key,
+            alice_to_bob_key,
+        );
+        let bob = Session::new(bob_receiving_index, 0, alice_to_bob_key, bob_to_alice_key);
+
+        (alice, bob)
+    }
+
+    #[test]
+    fn format_packet_data_round_trips_with_spare_capacity() {
+        let (alice, bob) = linked_sessions();
+
+        let mut bytes = bytes::BytesMut::with_capacity(128);
+        bytes.extend_from_slice(b"hello through the tunnel");
+
+        let packet = Packet::from_bytes(bytes);
+        let wg_packet = alice
+            .format_packet_data(packet)
+            .expect("counter is below reject-after limit");
+
+        assert_eq!(
+            wg_packet.header.receiver_idx.get(),
+            bob.receiving_index.value()
+        );
+        assert_eq!(wg_packet.header.counter.get(), 0);
+
+        let packet = bob
+            .receive_packet_data(wg_packet)
+            .expect("receiver has matching key and index");
+        assert_eq!(&*packet, b"hello through the tunnel");
+    }
+
+    #[test]
+    fn format_packet_data_round_trips_when_buffer_must_grow() {
+        let (alice, bob) = linked_sessions();
+
+        let payload = b"no spare capacity";
+        let mut bytes = bytes::BytesMut::with_capacity(payload.len());
+        bytes.extend_from_slice(payload);
+
+        let packet = Packet::from_bytes(bytes);
+        let wg_packet = alice
+            .format_packet_data(packet)
+            .expect("counter is below reject-after limit");
+
+        assert_eq!(
+            wg_packet.header.receiver_idx.get(),
+            bob.receiving_index.value()
+        );
+        assert_eq!(wg_packet.header.counter.get(), 0);
+
+        let packet = bob
+            .receive_packet_data(wg_packet)
+            .expect("receiver has matching key and index");
+        assert_eq!(&*packet, payload);
     }
 
     /// The receive path must reject a counter at/beyond REJECT_AFTER_MESSAGES before decryption,

--- a/gotatun/src/packet/mod.rs
+++ b/gotatun/src/packet/mod.rs
@@ -292,6 +292,22 @@ impl Packet<[u8]> {
         self.inner.buf.truncate(new_len);
     }
 
+    /// Grow this packet and move the current bytes after a new prefix.
+    ///
+    /// The added prefix and suffix are zero-filled.
+    pub(crate) fn prepend_and_append_space(mut self, prefix_len: usize, suffix_len: usize) -> Self {
+        let old_len = self.inner.buf.len();
+        let new_len = prefix_len
+            .checked_add(old_len)
+            .and_then(|len| len.checked_add(suffix_len))
+            .expect("packet length must fit in usize");
+
+        self.inner.buf.resize(new_len, 0);
+        self.inner.buf.copy_within(0..old_len, prefix_len);
+        self.inner.buf[..prefix_len].fill(0);
+        self
+    }
+
     /// Get direct mutable access to the backing buffer.
     pub fn buf_mut(&mut self) -> &mut BytesMut {
         &mut self.inner.buf
@@ -525,5 +541,41 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Packet").field(&self.deref()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+
+    use super::Packet;
+
+    #[test]
+    fn prepend_and_append_space_reuses_spare_capacity() {
+        let mut bytes = BytesMut::with_capacity(64);
+        bytes.extend_from_slice(b"payload");
+        let original_ptr = bytes.as_ptr();
+        let packet = Packet::from_bytes(bytes);
+
+        let packet = packet.prepend_and_append_space(4, 3);
+
+        assert_eq!(packet.as_ptr(), original_ptr);
+        assert_eq!(&packet[..4], &[0, 0, 0, 0]);
+        assert_eq!(&packet[4..11], b"payload");
+        assert_eq!(&packet[11..], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn prepend_and_append_space_preserves_payload_after_reallocation() {
+        let mut bytes = BytesMut::with_capacity(7);
+        bytes.extend_from_slice(b"payload");
+        let packet = Packet::from_bytes(bytes);
+
+        let packet = packet.prepend_and_append_space(16, 5);
+
+        assert_eq!(packet.len(), 28);
+        assert_eq!(&packet[..16], &[0; 16]);
+        assert_eq!(&packet[16..23], b"payload");
+        assert_eq!(&packet[23..], &[0, 0, 0, 0, 0]);
     }
 }


### PR DESCRIPTION
## Summary

Reuse the existing outbound packet buffer when wrapping a payload as a WireGuard data packet.

The previous path allocated a new buffer for every data packet, wrote the WireGuard data header into it, copied the payload after the header, and then appended the AEAD tag. This change uses the headroom and tailroom already reserved in the packet buffer when possible, moving the payload into place before writing the header and tag.

This is a small allocation/copy reduction for the outbound data path. It does not change the WireGuard packet format, encryption behavior, or fallback behavior when the packet buffer needs to grow.

## Changes

- Add packet-buffer helpers for prepending initialized space and appending initialized space.
- Move an outbound payload inside its existing packet buffer before encrypting it as a WireGuard data packet.
- Zero-fill the newly exposed prefix and suffix bytes before writing the data header and AEAD tag.
- Keep the existing fallback behavior when the packet buffer does not have enough spare capacity.

This follows the existing TODO in the data-packet wrapping path about avoiding the extra allocation by pre-allocating space before the payload.

## Runtime behavior

The resulting encrypted packet is intended to be identical to the previous path.

- The WireGuard data header is still written immediately before the encrypted payload.
- The AEAD tag is still appended after the encrypted payload.
- Packet buffers that need more capacity still grow before the header and tag are written.
- The newly exposed bytes are initialized before they are used.

## Testing

Tests cover:

- prepending initialized bytes when spare headroom is available;
- falling back when additional capacity is required;
- appending initialized bytes for the AEAD tag space;
- preserving packet contents while moving the payload; and
- encrypting outbound data packets through the reused-buffer path.

Locally passed:

- `cargo fmt --check`
- `cargo clippy --locked --workspace --all-targets --all-features`
- `cargo check --locked --workspace`
- `cargo hack check --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `cargo shear`
- `RUSTDOCFLAGS="--deny warnings" cargo hack doc --locked -p gotatun --each-feature --features aws-lc-rs`

## Out of scope

This PR intentionally does not change:

- inbound packet handling;
- UDP socket batching;
- WireGuard cryptography or replay behavior;
- packet layout beyond reusing the existing buffer allocation; or
- public API behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/169)
<!-- Reviewable:end -->
