### PR TITLE
Use Linux UDP GSO for compatible send batches

### DIFF
--- a/gotatun/src/udp/socket/linux.rs
+++ b/gotatun/src/udp/socket/linux.rs
@@ -9,13 +9,15 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+#[cfg(target_os = "linux")]
+use nix::sys::socket::ControlMessage;
 use nix::sys::socket::{MsgFlags, MultiHeaders, SockaddrStorage};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{setsockopt, sockopt};
 use std::{
     io::{self, IoSlice},
     net::SocketAddr,
-    os::fd::AsRawFd,
+    os::fd::{AsRawFd, RawFd},
 };
 use tokio::io::Interest;
 
@@ -27,9 +29,642 @@ use crate::{
 /// Max number of packets/messages for sendmmsg/recvmmsg
 const MAX_PACKET_COUNT: usize = 100;
 
+/// Maximum UDP payload length for one IPv4 datagram, accounting for IPv4 and UDP headers.
+#[cfg(target_os = "linux")]
+const MAX_IPV4_PAYLOAD_LEN: usize = (1 << 16) - 1 - 20 - 8;
+
+/// Maximum UDP payload length for one IPv6 datagram, accounting for the UDP header.
+#[cfg(target_os = "linux")]
+const MAX_IPV6_PAYLOAD_LEN: usize = (1 << 16) - 1 - 8;
+
+/// Kernel-imposed limit for UDP_SEGMENT datagrams in one coalesced message.
+#[cfg(target_os = "linux")]
+const UDP_SEGMENT_MAX_DATAGRAMS: usize = 64;
+
 #[derive(Default)]
 pub struct SendmmsgBuf {
     targets: Vec<Option<SockaddrStorage>>,
+    #[cfg(target_os = "linux")]
+    gso_batches: Vec<UdpGsoBatch>,
+}
+
+#[cfg(all(test, target_os = "linux"))]
+impl SendmmsgBuf {
+    fn gso_batches(&self) -> &[UdpGsoBatch] {
+        &self.gso_batches
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct UdpGsoBatch {
+    start: usize,
+    datagrams: usize,
+    target: SocketAddr,
+    segment_size: usize,
+    payload_len: usize,
+}
+
+#[cfg(target_os = "linux")]
+fn plan_udp_gso_batches<I>(packets: I, batches: &mut Vec<UdpGsoBatch>)
+where
+    I: IntoIterator<Item = (usize, SocketAddr)>,
+{
+    batches.clear();
+    let mut end_batch = false;
+
+    for (packet_index, (packet_len, target)) in packets.into_iter().enumerate() {
+        if let Some(batch) = batches.last_mut() {
+            let max_payload_len = if batch.target.is_ipv6() {
+                MAX_IPV6_PAYLOAD_LEN
+            } else {
+                MAX_IPV4_PAYLOAD_LEN
+            };
+            let can_coalesce = batch.payload_len + packet_len <= max_payload_len
+                && batch.segment_size != 0
+                && packet_len != 0
+                && packet_len <= batch.segment_size
+                && batch.datagrams < UDP_SEGMENT_MAX_DATAGRAMS
+                && target == batch.target
+                && !end_batch;
+
+            if can_coalesce {
+                batch.payload_len += packet_len;
+                batch.datagrams += 1;
+                if packet_len < batch.segment_size {
+                    end_batch = true;
+                }
+                continue;
+            }
+        }
+
+        end_batch = false;
+        batches.push(UdpGsoBatch {
+            start: packet_index,
+            datagrams: 1,
+            target,
+            segment_size: packet_len,
+            payload_len: packet_len,
+        });
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn udp_gso_segment_size(batch: &UdpGsoBatch) -> Option<u16> {
+    if batch.datagrams <= 1 || batch.segment_size == 0 {
+        return None;
+    }
+
+    u16::try_from(batch.segment_size).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn udp_gso_control_messages(segment_size: &u16) -> [ControlMessage<'_>; 1] {
+    [ControlMessage::UdpGsoSegments(segment_size)]
+}
+
+#[cfg(target_os = "linux")]
+fn should_disable_udp_gso(err: &io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EIO)
+}
+
+struct SendBatch<'a, 'p> {
+    socket: &'a tokio::net::UdpSocket,
+    fd: RawFd,
+    pkts: &'a [[IoSlice<'p>; 1]],
+    targets: &'a [Option<SockaddrStorage>],
+}
+
+async fn send_plain_range(
+    batch: &SendBatch<'_, '_>,
+    mut packet_buf_start: usize,
+    packet_buf_end: usize,
+) -> io::Result<()> {
+    while packet_buf_start < packet_buf_end {
+        let result = batch
+            .socket
+            .async_io(Interest::WRITABLE, || {
+                let mut multiheaders =
+                    MultiHeaders::preallocate(packet_buf_end - packet_buf_start, None);
+                let multiresult = nix::sys::socket::sendmmsg(
+                    batch.fd,
+                    &mut multiheaders,
+                    &batch.pkts[packet_buf_start..packet_buf_end],
+                    &batch.targets[packet_buf_start..packet_buf_end],
+                    [],
+                    MsgFlags::MSG_DONTWAIT,
+                )?;
+                Ok(multiresult.count())
+            })
+            .await;
+        let n = result?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "sendmmsg sent zero UDP datagrams",
+            ));
+        }
+        packet_buf_start += n;
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn send_gso_segment(
+    udp_socket: &super::UdpSocket,
+    batch: &SendBatch<'_, '_>,
+    start: usize,
+    datagrams: usize,
+    segment_size: u16,
+) -> io::Result<()> {
+    let end = start + datagrams;
+    let mut segment_iovs = [IoSlice::new(&[]); UDP_SEGMENT_MAX_DATAGRAMS];
+    for (dst, packet_iov) in segment_iovs.iter_mut().zip(&batch.pkts[start..end]) {
+        *dst = packet_iov[0];
+    }
+    let segment_iovs = &segment_iovs[..datagrams];
+    let cmsgs = udp_gso_control_messages(&segment_size);
+
+    let result = batch
+        .socket
+        .async_io(Interest::WRITABLE, || {
+            let mut multiheaders = MultiHeaders::preallocate(1, Some(nix::cmsg_space!(u16)));
+            let multiresult = nix::sys::socket::sendmmsg(
+                batch.fd,
+                &mut multiheaders,
+                [&segment_iovs],
+                &batch.targets[start..start + 1],
+                cmsgs,
+                MsgFlags::MSG_DONTWAIT,
+            )?;
+            Ok(multiresult.count())
+        })
+        .await;
+
+    match result {
+        Ok(1) => Ok(()),
+        Ok(0) => Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "sendmmsg sent zero UDP GSO segments",
+        )),
+        Ok(_) => unreachable!("one UDP GSO message was submitted"),
+        Err(err) if should_disable_udp_gso(&err) => {
+            udp_socket.disable_udp_gso();
+            send_plain_range(batch, start, end).await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod gso_tests {
+    use super::{
+        MAX_IPV4_PAYLOAD_LEN, MAX_IPV6_PAYLOAD_LEN, UDP_SEGMENT_MAX_DATAGRAMS, UdpGsoBatch,
+        plan_udp_gso_batches, udp_gso_control_messages, udp_gso_segment_size,
+    };
+    use nix::sys::socket::ControlMessage;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    fn target(port: u16) -> SocketAddr {
+        (Ipv4Addr::LOCALHOST, port).into()
+    }
+
+    fn target_v6(port: u16) -> SocketAddr {
+        (Ipv6Addr::LOCALHOST, port).into()
+    }
+
+    fn plan(packet_lens: &[usize], packet_targets: &[SocketAddr], batches: &mut Vec<UdpGsoBatch>) {
+        plan_udp_gso_batches(
+            packet_lens
+                .iter()
+                .copied()
+                .zip(packet_targets.iter().copied()),
+            batches,
+        );
+    }
+
+    #[test]
+    fn gso_plan_coalesces_equal_datagrams() {
+        let mut batches = Vec::new();
+        plan(
+            &[1200, 1200, 1200],
+            &[target(1000), target(1000), target(1000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![UdpGsoBatch {
+                start: 0,
+                datagrams: 3,
+                target: target(1000),
+                segment_size: 1200,
+                payload_len: 3600,
+            }]
+        );
+    }
+
+    #[test]
+    fn gso_plan_allows_short_tail_then_starts_new_batch() {
+        let mut batches = Vec::new();
+        plan(
+            &[1200, 800, 1200],
+            &[target(1000), target(1000), target(1000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 2,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 2000,
+                },
+                UdpGsoBatch {
+                    start: 2,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 1200,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_splits_at_segment_count_limit() {
+        let packets = vec![1000; UDP_SEGMENT_MAX_DATAGRAMS + 1];
+        let targets = vec![target(1000); packets.len()];
+        let mut batches = Vec::new();
+        plan(&packets, &targets, &mut batches);
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: UDP_SEGMENT_MAX_DATAGRAMS,
+                    target: target(1000),
+                    segment_size: 1000,
+                    payload_len: 1000 * UDP_SEGMENT_MAX_DATAGRAMS,
+                },
+                UdpGsoBatch {
+                    start: UDP_SEGMENT_MAX_DATAGRAMS,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 1000,
+                    payload_len: 1000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_splits_at_ipv4_payload_limit() {
+        let segment_size = MAX_IPV4_PAYLOAD_LEN / 2 + 1;
+        let mut batches = Vec::new();
+        plan(
+            &[segment_size, segment_size],
+            &[target(1000), target(1000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size,
+                    payload_len: segment_size,
+                },
+                UdpGsoBatch {
+                    start: 1,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size,
+                    payload_len: segment_size,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_uses_ipv6_payload_limit() {
+        let segment_size = MAX_IPV6_PAYLOAD_LEN / 2;
+        let packet_lens = [segment_size, segment_size, 2];
+        let packet_targets = [target_v6(1000), target_v6(1000), target_v6(1000)];
+        let mut batches = Vec::new();
+
+        plan(&packet_lens, &packet_targets, &mut batches);
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 2,
+                    target: target_v6(1000),
+                    segment_size,
+                    payload_len: segment_size * 2,
+                },
+                UdpGsoBatch {
+                    start: 2,
+                    datagrams: 1,
+                    target: target_v6(1000),
+                    segment_size: 2,
+                    payload_len: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_splits_at_destination_changes() {
+        let mut batches = Vec::new();
+        plan(
+            &[1200, 1200, 1200],
+            &[target(1000), target(2000), target(2000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 1200,
+                },
+                UdpGsoBatch {
+                    start: 1,
+                    datagrams: 2,
+                    target: target(2000),
+                    segment_size: 1200,
+                    payload_len: 2400,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_does_not_coalesce_zero_length_datagrams() {
+        let mut batches = Vec::new();
+        plan(
+            &[1200, 0, 1200, 0],
+            &[target(1000), target(1000), target(1000), target(1000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 1200,
+                },
+                UdpGsoBatch {
+                    start: 1,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 0,
+                    payload_len: 0,
+                },
+                UdpGsoBatch {
+                    start: 2,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 1200,
+                },
+                UdpGsoBatch {
+                    start: 3,
+                    datagrams: 1,
+                    target: target(1000),
+                    segment_size: 0,
+                    payload_len: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_plan_splits_at_address_family_changes() {
+        let mut batches = Vec::new();
+        plan(
+            &[1200, 1200, 1200, 1200],
+            &[target(1000), target(1000), target_v6(1000), target_v6(1000)],
+            &mut batches,
+        );
+
+        assert_eq!(
+            batches,
+            vec![
+                UdpGsoBatch {
+                    start: 0,
+                    datagrams: 2,
+                    target: target(1000),
+                    segment_size: 1200,
+                    payload_len: 2400,
+                },
+                UdpGsoBatch {
+                    start: 2,
+                    datagrams: 2,
+                    target: target_v6(1000),
+                    segment_size: 1200,
+                    payload_len: 2400,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn gso_segment_size_only_emits_for_coalesced_batches() {
+        assert_eq!(
+            udp_gso_segment_size(&UdpGsoBatch {
+                start: 0,
+                datagrams: 3,
+                target: target(1000),
+                segment_size: 1200,
+                payload_len: 3200,
+            }),
+            Some(1200)
+        );
+        assert_eq!(
+            udp_gso_segment_size(&UdpGsoBatch {
+                start: 3,
+                datagrams: 1,
+                target: target(1000),
+                segment_size: 1200,
+                payload_len: 1200,
+            }),
+            None
+        );
+        assert_eq!(
+            udp_gso_segment_size(&UdpGsoBatch {
+                start: 4,
+                datagrams: 2,
+                target: target(1000),
+                segment_size: 0,
+                payload_len: 0,
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn gso_segment_size_rejects_oversized_segment() {
+        assert_eq!(
+            udp_gso_segment_size(&UdpGsoBatch {
+                start: 0,
+                datagrams: 2,
+                target: target(1000),
+                segment_size: usize::from(u16::MAX) + 1,
+                payload_len: (usize::from(u16::MAX) + 1) * 2,
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn udp_gso_control_message_uses_udp_segment_size() {
+        let segment_size = 1200;
+        let [cmsg] = udp_gso_control_messages(&segment_size);
+
+        assert_eq!(cmsg, ControlMessage::UdpGsoSegments(&segment_size));
+    }
+
+    #[test]
+    fn eio_disables_udp_gso() {
+        let error = std::io::Error::from_raw_os_error(libc::EIO);
+        assert!(super::should_disable_udp_gso(&error));
+
+        let error = std::io::Error::from_raw_os_error(libc::ECONNREFUSED);
+        assert!(!super::should_disable_udp_gso(&error));
+    }
+
+    #[tokio::test]
+    async fn send_many_to_records_reusable_gso_plan() {
+        use crate::packet::PacketBufPool;
+        use crate::udp::UdpSend;
+        use crate::udp::socket::SockOpt;
+        use std::net::{Ipv4Addr, SocketAddr};
+        use std::time::Duration;
+
+        let socket = crate::udp::socket::UdpSocket::bind(
+            (Ipv4Addr::LOCALHOST, 0).into(),
+            SockOpt::default(),
+        )
+        .unwrap();
+        let receiver = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let target: SocketAddr = receiver.local_addr().unwrap();
+        let pool = PacketBufPool::<4096>::new(4);
+        let mut send_buf = super::SendmmsgBuf::default();
+        let mut packets = [1200usize, 1200, 800]
+            .into_iter()
+            .map(|len| {
+                let mut packet = pool.get();
+                packet.truncate(len);
+                packet.fill(0x42);
+                (packet, target)
+            })
+            .collect();
+
+        socket
+            .send_many_to(&mut send_buf, &mut packets)
+            .await
+            .unwrap();
+
+        assert!(packets.is_empty());
+        assert_eq!(
+            send_buf.gso_batches(),
+            &[UdpGsoBatch {
+                start: 0,
+                datagrams: 3,
+                target,
+                segment_size: 1200,
+                payload_len: 3200,
+            }]
+        );
+
+        receiver
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut received_lens = Vec::new();
+        let mut recv_buf = vec![0u8; 1200];
+        for _ in 0..3 {
+            let (len, from) = receiver.recv_from(&mut recv_buf).unwrap();
+            assert_eq!(from, socket.local_addr().unwrap());
+            received_lens.push(len);
+        }
+        assert_eq!(received_lens, vec![1200, 1200, 800]);
+    }
+
+    #[tokio::test]
+    async fn send_many_to_records_ipv6_gso_plan() {
+        use crate::packet::PacketBufPool;
+        use crate::udp::UdpSend;
+        use crate::udp::socket::SockOpt;
+        use std::time::Duration;
+
+        let socket = crate::udp::socket::UdpSocket::bind(
+            (Ipv6Addr::LOCALHOST, 0).into(),
+            SockOpt::default(),
+        )
+        .unwrap();
+        let receiver = std::net::UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+        let target: SocketAddr = receiver.local_addr().unwrap();
+        let pool = PacketBufPool::<4096>::new(4);
+        let mut send_buf = super::SendmmsgBuf::default();
+        let mut packets = [900usize, 900, 700]
+            .into_iter()
+            .map(|len| {
+                let mut packet = pool.get();
+                packet.truncate(len);
+                packet.fill(0x24);
+                (packet, target)
+            })
+            .collect();
+
+        socket
+            .send_many_to(&mut send_buf, &mut packets)
+            .await
+            .unwrap();
+
+        assert!(packets.is_empty());
+        assert_eq!(
+            send_buf.gso_batches(),
+            &[UdpGsoBatch {
+                start: 0,
+                datagrams: 3,
+                target,
+                segment_size: 900,
+                payload_len: 2500,
+            }]
+        );
+
+        receiver
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut received_lens = Vec::new();
+        let mut recv_buf = vec![0u8; 900];
+        for _ in 0..3 {
+            let (len, from) = receiver.recv_from(&mut recv_buf).unwrap();
+            assert_eq!(from, socket.local_addr().unwrap());
+            received_lens.push(len);
+        }
+        assert_eq!(received_lens, vec![900, 900, 700]);
+    }
 }
 
 impl UdpSend for super::UdpSocket {
@@ -60,30 +695,66 @@ impl UdpSend for super::UdpSocket {
             *packets_buf = [IoSlice::new(&packet[..])];
         }
 
-        let len = buf.targets.len();
-        let pkts = &packets_buf[..len];
-        let mut packet_buf_start = 0;
-        while packet_buf_start < len {
-            let result = socket
-                .async_io(Interest::WRITABLE, || {
-                    let mut multiheaders =
-                        MultiHeaders::preallocate(pkts[packet_buf_start..].len(), None);
-                    let multiresult = nix::sys::socket::sendmmsg(
-                        fd,
-                        &mut multiheaders,
-                        &pkts[packet_buf_start..],
-                        &buf.targets[packet_buf_start..],
-                        [],
-                        MsgFlags::MSG_DONTWAIT,
-                    )?;
-                    let n = multiresult.count();
-                    Ok(n)
-                })
-                .await;
-            let n = result?;
-            packet_buf_start += n;
+        let pkts = &packets_buf[..buf.targets.len()];
+        let batch = SendBatch {
+            socket,
+            fd,
+            pkts,
+            targets: &buf.targets,
+        };
+
+        #[cfg(target_os = "linux")]
+        {
+            plan_udp_gso_batches(
+                packets
+                    .iter()
+                    .map(|(packet, target)| (packet.len(), *target)),
+                &mut buf.gso_batches,
+            );
+
+            if self.udp_gso_supported() && !self.udp_gso_disabled() {
+                let mut plain_start = None;
+
+                for gso_batch in &buf.gso_batches {
+                    let Some(segment_size) = udp_gso_segment_size(gso_batch) else {
+                        plain_start.get_or_insert(gso_batch.start);
+                        continue;
+                    };
+
+                    if let Some(start) = plain_start.take() {
+                        send_plain_range(&batch, start, gso_batch.start).await?;
+                    }
+
+                    if self.udp_gso_disabled() {
+                        send_plain_range(
+                            &batch,
+                            gso_batch.start,
+                            gso_batch.start + gso_batch.datagrams,
+                        )
+                        .await?;
+                    } else {
+                        send_gso_segment(
+                            self,
+                            &batch,
+                            gso_batch.start,
+                            gso_batch.datagrams,
+                            segment_size,
+                        )
+                        .await?;
+                    }
+                }
+
+                if let Some(start) = plain_start {
+                    send_plain_range(&batch, start, buf.targets.len()).await?;
+                }
+            } else {
+                send_plain_range(&batch, 0, buf.targets.len()).await?;
+            }
         }
-        debug_assert!(packet_buf_start == len, "all packets should be sent");
+        #[cfg(not(target_os = "linux"))]
+        {
+            send_plain_range(&batch, 0, buf.targets.len()).await?;
+        }
         packets.clear();
 
         Ok(())

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -11,6 +11,10 @@
 
 //! Implementations of [`super::UdpSend`] and [`super::UdpRecv`] traits for [`UdpSocket`].
 
+#[cfg(target_os = "linux")]
+use nix::sys::socket::{getsockopt, sockopt};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -94,9 +98,17 @@ pub struct UdpSocket {
 
 #[derive(Clone)]
 enum UdpSocketInner {
-    Socket(Arc<tokio::net::UdpSocket>),
+    Socket(Arc<UdpSocketState>),
     #[cfg(target_os = "linux")]
     DisabledIpv6,
+}
+
+struct UdpSocketState {
+    socket: tokio::net::UdpSocket,
+    #[cfg(target_os = "linux")]
+    udp_gso_supported: bool,
+    #[cfg(target_os = "linux")]
+    udp_gso_disabled: AtomicBool,
 }
 
 /// Options set on the socket created by [`UdpSocket::bind`].
@@ -156,11 +168,19 @@ impl UdpSocket {
         }
 
         udp_sock.bind(&addr.into())?;
+        #[cfg(target_os = "linux")]
+        let udp_gso_supported = getsockopt(&udp_sock, sockopt::UdpGsoSegment).is_ok();
 
         let inner = tokio::net::UdpSocket::from_std(udp_sock.into())?;
 
         Ok(Self {
-            inner: UdpSocketInner::Socket(Arc::new(inner)),
+            inner: UdpSocketInner::Socket(Arc::new(UdpSocketState {
+                socket: inner,
+                #[cfg(target_os = "linux")]
+                udp_gso_supported,
+                #[cfg(target_os = "linux")]
+                udp_gso_disabled: AtomicBool::new(false),
+            })),
         })
     }
 
@@ -176,6 +196,29 @@ impl UdpSocket {
         matches!(&self.inner, UdpSocketInner::DisabledIpv6)
     }
 
+    #[cfg(target_os = "linux")]
+    pub(crate) fn udp_gso_disabled(&self) -> bool {
+        match &self.inner {
+            UdpSocketInner::Socket(state) => state.udp_gso_disabled.load(Ordering::Relaxed),
+            UdpSocketInner::DisabledIpv6 => true,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn udp_gso_supported(&self) -> bool {
+        match &self.inner {
+            UdpSocketInner::Socket(state) => state.udp_gso_supported,
+            UdpSocketInner::DisabledIpv6 => false,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn disable_udp_gso(&self) {
+        if let UdpSocketInner::Socket(state) = &self.inner {
+            state.udp_gso_disabled.store(true, Ordering::Relaxed);
+        }
+    }
+
     /// Get the inner [`tokio::net::UdpSocket`].
     ///
     /// # Linux
@@ -183,7 +226,7 @@ impl UdpSocket {
     #[inline(always)]
     pub fn socket(&self) -> io::Result<&tokio::net::UdpSocket> {
         match &self.inner {
-            UdpSocketInner::Socket(socket) => Ok(socket),
+            UdpSocketInner::Socket(state) => Ok(&state.socket),
             #[cfg(target_os = "linux")]
             UdpSocketInner::DisabledIpv6 => Err(disabled_ipv6_error()),
         }
@@ -348,6 +391,22 @@ mod tests {
             bind_ipv4_socket(Ipv4Addr::LOCALHOST, 0, SockOpt::default()).expect("bind IPv4");
 
         assert!(socket.local_addr().unwrap().is_ipv4());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn udp_gso_disabled_state_is_shared_by_clones() {
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0).into(), SockOpt::default()).unwrap();
+        let clone = socket.clone();
+
+        assert_eq!(socket.udp_gso_supported(), clone.udp_gso_supported());
+        assert!(!socket.udp_gso_disabled());
+        assert!(!clone.udp_gso_disabled());
+
+        clone.disable_udp_gso();
+
+        assert!(socket.udp_gso_disabled());
+        assert!(clone.udp_gso_disabled());
     }
 
     /// Test that `bind_sockets` retries when the IPv6 port is already in use.


### PR DESCRIPTION
## Summary

Add a Linux UDP GSO send path for compatible outbound `send_many_to` batches.

When a socket supports UDP segmentation offload and a batch contains packets that can be represented as equal-sized GSO segments, this change coalesces those packets into one larger datagram and sends it with a `UDP_SEGMENT` control message. Unsupported or unsuitable batches continue to use the existing plain `sendmmsg` path.

This is Linux-only execution-path work. Non-Linux platforms keep the existing implementation.

## Changes

### GSO eligibility and planning

- Detect UDP GSO support when binding the Linux UDP socket.
- Plan GSO sends only for non-empty packets with compatible destination, address family, payload size, and segment sizing.
- Keep mixed-family or otherwise incompatible batches on the existing plain send path.
- Split fallback sends back into the original packet boundaries.

### Send path

- Add a Linux-only GSO `send_many_to` fast path.
- Build the `UDP_SEGMENT` control message for eligible batches.
- Fall back to the existing plain `sendmmsg` path when GSO is unavailable, disabled, or unsuitable for the batch.
- Disable future GSO attempts on the socket after an `EIO` fallback signal.

### Platform isolation

- Keep the GSO-specific code behind Linux cfg boundaries.
- Leave other platform send paths unchanged.

## Runtime behavior

WireGuard packet boundaries and ordering are intended to remain unchanged from the caller's point of view.

- Eligible packets may be coalesced for a single Linux UDP send.
- Unsupported packets are sent through the previous plain path.
- Zero-length packets are not coalesced into a GSO datagram.
- IPv4 and IPv6 batches are handled explicitly.
- If the kernel reports an `EIO` fallback condition, the socket disables GSO and retries through the plain path.

## Performance note

I checked this in a local VM guardrail setup used while working on [Gatherlink MultiLink](https://github.com/markus-li/gatherlink). In that setup, this branch improved same-run GotaTun TCP throughput by about `+157%` on a clean multi-path case and `+148%` on the TCP side of the UDP-clean case. UDP received goodput stayed at the configured `500 Mbit/s` offered-rate ceiling with `0%` loss.

These numbers are local guardrail evidence, not a general throughput claim.

## Testing

Tests cover:

- GSO planning and segmentation limits;
- IPv4 and IPv6 control-message construction;
- destination and address-family splits;
- zero-length packet handling;
- fallback expansion back to original packet boundaries;
- unsupported-GSO fallback behavior; and
- disabled-state behavior after an `EIO` fallback signal.

Locally passed:

- `cargo fmt --all --check`
- `cargo check --locked -p gotatun`
- `cargo check --locked -p gotatun --features device,tun`
- `cargo test --locked -p gotatun udp::socket::linux::gso_tests -- --nocapture`
- `RUSTFLAGS="--deny warnings" cargo clippy --locked --workspace --all-targets --all-features`
- `cargo hack check --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `cargo shear`
- `RUSTDOCFLAGS="--deny warnings" cargo hack doc --locked -p gotatun --each-feature --features aws-lc-rs`

## Out of scope

This PR intentionally does not change:

- receive-side batching;
- WireGuard packet construction or encryption;
- non-Linux UDP send behavior;
- scheduling or queueing policy above `send_many_to`; or
- the existing plain `sendmmsg` fallback path for unsupported batches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/170)
<!-- Reviewable:end -->
