### PR TITLE
Send persistent keepalive immediately on peer activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Keep IPv4 fragments for different protocols in separate reassembly buffers.
+- Send persistent keepalive immediately on peer activation, instead of waiting for one full
+  interval. This matches wireguard-go and Linux kernel wireguard.
 
 
 ## [0.8.1] - 2026-07-14

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -580,8 +580,6 @@ impl<T: DeviceTransports> DeviceState<T> {
     #[instrument(level = Level::TRACE, skip_all)]
     async fn handle_timers(device: Weak<RwLock<Self>>, udp4: impl UdpSend, udp6: impl UdpSend) {
         loop {
-            tokio::time::sleep(Duration::from_millis(250)).await;
-
             let Some(device) = device.upgrade() else {
                 break;
             };
@@ -630,6 +628,9 @@ impl<T: DeviceTransports> DeviceState<T> {
                     Err(e) => tracing::error!("Timer error = {e:?}: {e:?}"),
                 }
             }
+
+            drop(device);
+            tokio::time::sleep(Duration::from_millis(250)).await;
         }
     }
 

--- a/gotatun/src/noise/mod.rs
+++ b/gotatun/src/noise/mod.rs
@@ -546,6 +546,10 @@ mod tests {
     use mock_instant::thread_local::MockClock;
 
     fn create_two_tuns() -> (Tunn, Tunn) {
+        create_two_tuns_with_keepalive(None)
+    }
+
+    fn create_two_tuns_with_keepalive(persistent_keepalive: Option<u16>) -> (Tunn, Tunn) {
         let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
         let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
 
@@ -557,7 +561,7 @@ mod tests {
             my_secret_key,
             their_public_key,
             None,
-            None,
+            persistent_keepalive,
             IndexTable::from_os_rng(),
             rate_limiter,
         );
@@ -639,7 +643,6 @@ mod tests {
         packet.try_into_ipvx().unwrap().unwrap_left()
     }
 
-    #[cfg(feature = "mock_instant")]
     fn update_timer_results_in_handshake(tun: &mut Tunn) {
         let packet = tun
             .update_timers()
@@ -657,6 +660,39 @@ mod tests {
     fn handshake_init() {
         let (mut my_tun, _their_tun) = create_two_tuns();
         let _init = create_handshake_init(&mut my_tun);
+    }
+
+    #[test]
+    fn configured_persistent_keepalive_remains_immediate_after_reset_and_update() {
+        let (mut my_tun, _their_tun) = create_two_tuns_with_keepalive(Some(25));
+
+        update_timer_results_in_handshake(&mut my_tun);
+        assert!(matches!(my_tun.update_timers(), Ok(None)));
+        my_tun.reset();
+        my_tun.set_persistent_keepalive(Some(30));
+        update_timer_results_in_handshake(&mut my_tun);
+    }
+
+    #[test]
+    #[cfg(feature = "mock_instant")]
+    fn persistent_keepalive_uses_configured_interval_after_initial_send() {
+        const INTERVAL: Duration = Duration::from_secs(25);
+
+        MockClock::set_time(Duration::ZERO);
+        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake();
+        my_tun.set_persistent_keepalive(Some(25));
+        assert!(matches!(
+            my_tun.update_timers(),
+            Ok(Some(WgKind::Data(packet))) if packet.is_keepalive()
+        ));
+
+        MockClock::advance(INTERVAL - Duration::from_millis(1));
+        assert!(matches!(my_tun.update_timers(), Ok(None)));
+        MockClock::advance(Duration::from_millis(1));
+        assert!(matches!(
+            my_tun.update_timers(),
+            Ok(Some(WgKind::Data(packet))) if packet.is_keepalive()
+        ));
     }
 
     #[test]

--- a/gotatun/src/noise/timers.rs
+++ b/gotatun/src/noise/timers.rs
@@ -118,6 +118,7 @@ pub struct Timers {
     /// First data packet sent without hearing back
     want_handshake: Option<Duration>,
     persistent_keepalive: Option<Duration>,
+    persistent_keepalive_due: bool,
     /// Timer deadline ranges that the sampled deadlines below are drawn from.
     pub(super) params: TimerParams,
     /// Current passive keepalive deadline.
@@ -136,6 +137,9 @@ pub struct Timers {
 
 impl Timers {
     pub(super) fn new(persistent_keepalive: Option<u16>) -> Timers {
+        let persistent_keepalive = persistent_keepalive
+            .filter(|&s| s > 0)
+            .map(|s| Duration::from_secs(s.into()));
         let mut timers = Timers {
             is_initiator: false,
             time_started: Instant::now(),
@@ -143,9 +147,8 @@ impl Timers {
             session_timers: Default::default(),
             want_keepalive: Default::default(),
             want_handshake: Default::default(),
-            persistent_keepalive: persistent_keepalive
-                .filter(|&s| s > 0)
-                .map(|s| Duration::from_secs(s.into())),
+            persistent_keepalive,
+            persistent_keepalive_due: persistent_keepalive.is_some(),
             params: TimerParams::default(),
             keepalive_timeout: Duration::ZERO,
             new_handshake_timeout: Duration::ZERO,
@@ -180,6 +183,7 @@ impl Timers {
         }
         self.want_handshake = None;
         self.want_keepalive = None;
+        self.persistent_keepalive_due = self.persistent_keepalive.is_some();
         self.dangerously_set_params(self.params.clone());
     }
 
@@ -214,6 +218,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
         match timer_name {
             TimeLastPacketReceived => {
                 self.timers.want_handshake = None;
+                self.timers.persistent_keepalive_due = false;
 
                 // Reset persistent keepalive timer for any authenticated packet
                 // Ref: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L215-L220
@@ -229,6 +234,7 @@ impl<R: rand::RngCore + Send> Tunn<R> {
             TimeLastDataPacketReceived => {}
             TimeLastPacketSent => {
                 self.timers.want_keepalive = None;
+                self.timers.persistent_keepalive_due = false;
 
                 // Reset persistent keepalive timer for any authenticated packet
                 // Ref: https://github.com/torvalds/linux/blob/9716c086c8e8b141d35aa61f2e96a2e83de212a7/drivers/net/wireguard/timers.c#L215-L220
@@ -421,10 +427,12 @@ impl<R: rand::RngCore + Send> Tunn<R> {
 
                     // Persistent KEEPALIVE
                     if let Some(persistent_keepalive) = persistent_keepalive
-                        && (now.saturating_sub(self.timers[TimePersistentKeepalive])
-                            >= persistent_keepalive)
+                        && (self.timers.persistent_keepalive_due
+                            || now.saturating_sub(self.timers[TimePersistentKeepalive])
+                                >= persistent_keepalive)
                     {
                         tracing::trace!("KEEPALIVE(PERSISTENT_KEEPALIVE)");
+                        self.timers.persistent_keepalive_due = false;
                         self.timer_tick(TimePersistentKeepalive);
                         keepalive_required = true;
                     }
@@ -485,9 +493,12 @@ impl<R: rand::RngCore + Send> Tunn<R> {
     ///
     /// Pass `None` or `Some(0)` to disable persistent keepalive.
     pub fn set_persistent_keepalive(&mut self, seconds: Option<u16>) {
+        let was_enabled = self.timers.persistent_keepalive.is_some();
         self.timers.persistent_keepalive = seconds
             .filter(|&s| s > 0)
             .map(|s| Duration::from_secs(s.into()));
+        self.timers.persistent_keepalive_due = self.timers.persistent_keepalive.is_some()
+            && (self.timers.persistent_keepalive_due || !was_enabled);
         if self.timers.persistent_keepalive.is_none() {
             self.timers[TimePersistentKeepalive] = Duration::ZERO;
         } else {


### PR DESCRIPTION
As the title says, this PR makes it so the first persistent keepalive is sent immediately when a peer is activated. This matches [wireguard-go's interface-up behavior](https://git.zx2c4.com/wireguard-go/tree/device/device.go#n712) and [Linux WireGuard's disabled-to-enabled behavior](https://git.zx2c4.com/wireguard-linux/tree/drivers/net/wireguard/netlink.c#n1028).

This fixes #171. Previously, the first keepalive was delayed by one full interval.

Changes:
- Mark a keepalive as due when a peer is created, reset, or has persistent keepalive enabled.
- Poll device timers immediately at startup so the first keepalive is not delayed.
- After the first send or authenticated traffic, continue using the configured interval.
- Add regression tests for activation, reset, and later keepalive timing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/172)
<!-- Reviewable:end -->
