### PR TITLE
Remove panics from send and recv tasks

### DIFF
--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -102,7 +102,7 @@ impl IpSend for BufferedIpSend {
         self.tx
             .send(packet)
             .await
-            .expect("receiver dropped after senders");
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
         Ok(())
     }
 }

--- a/gotatun/src/tun/channel.rs
+++ b/gotatun/src/tun/channel.rs
@@ -72,7 +72,7 @@ impl IpSend for TunChannelTx {
                         self.tun_tx_v4
                             .send(udp_packet)
                             .await
-                            .expect("receiver exists");
+                            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
                     }
                     Err(e) => tracing::trace!("Invalid UDP packet: {e:?}"),
                 }
@@ -82,7 +82,7 @@ impl IpSend for TunChannelTx {
                     self.tun_tx_v6
                         .send(udp_packet)
                         .await
-                        .expect("receiver exists");
+                        .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
                 }
                 Err(e) => tracing::trace!("Invalid UDP packet: {e:?}"),
             },

--- a/gotatun/src/udp/buffer.rs
+++ b/gotatun/src/udp/buffer.rs
@@ -100,7 +100,7 @@ impl UdpSend for BufferedUdpSend {
         };
         tx.send((packet, destination))
             .await
-            .expect("receiver task is never stopped while Self exists");
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
         Ok(())
     }
 

--- a/gotatun/src/udp/channel.rs
+++ b/gotatun/src/udp/channel.rs
@@ -236,7 +236,10 @@ impl UdpSend for UdpChannelTx {
                     dest.port(),
                     &udp_payload,
                 );
-                self.udp_tx_v4.send(ipv4).await.expect("receiver exists");
+                self.udp_tx_v4
+                    .send(ipv4)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
             }
             SocketAddr::V6(dest) => {
                 let ipv6 = create_ipv6_payload(
@@ -247,7 +250,10 @@ impl UdpSend for UdpChannelTx {
                     &udp_payload,
                     self.connection_id,
                 );
-                self.udp_tx_v6.send(ipv6).await.expect("receiver exists");
+                self.udp_tx_v6
+                    .send(ipv6)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
             }
         };
 
@@ -258,7 +264,11 @@ impl UdpRecv for UdpChannelV4Rx {
     type RecvManyBuf = ();
 
     async fn recv_from(&mut self, _pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
-        let ipv4 = self.udp_rx_v4.recv().await.expect("sender exists");
+        let ipv4 = self
+            .udp_rx_v4
+            .recv()
+            .await
+            .ok_or(io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))?;
 
         let source_addr = ipv4.header.source();
 
@@ -277,7 +287,11 @@ impl UdpRecv for UdpChannelV6Rx {
     type RecvManyBuf = ();
 
     async fn recv_from(&mut self, _pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
-        let ipv6 = self.udp_rx_v6.recv().await.expect("sender exists");
+        let ipv6 = self
+            .udp_rx_v6
+            .recv()
+            .await
+            .ok_or(io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))?;
 
         let source_addr = ipv6.header.source();
 


### PR DESCRIPTION
The Udp/IP Send/Recv implementations paniced on closed channels. This didn't propagate all the way to the main thread, as they lived in separate tasks, but we should still not panic and pollute the logs without a good cause.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/177)
<!-- Reviewable:end -->
