### PR TITLE
Validate IPv4 option checksums and lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hide native UDP socket impls behind new `socket` feature.
 
 ### Fixed
+- Validate IPv4 checksums and total lengths against the full IHL-declared header.
 - Keep IPv4 fragments for different protocols in separate reassembly buffers.
 - Send persistent keepalive immediately on peer activation, instead of waiting for one full
   interval. This matches wireguard-go and Linux kernel wireguard.

--- a/gotatun/src/packet/ipv4/mod.rs
+++ b/gotatun/src/packet/ipv4/mod.rs
@@ -134,20 +134,28 @@ impl Decoder<[u8], Ipv4<[u8]>> for Ipv4Decoder {
 
 fn validate_ipv4(d: &Ipv4Decoder, ipv4: &Ipv4) -> Result<usize, DecodeError> {
     let buf_len = ipv4.as_bytes().len();
+    let header_len = usize::from(ipv4.header.ihl()) * size_of::<u32>();
 
     if d.version && ipv4.header.version() != 4 {
         return Err(DecodeError::InvalidValue("version"));
     }
 
     if d.checksum {
-        let expected_csum = ipv4.header.compute_checksum();
+        let header = ipv4
+            .as_bytes()
+            .get(..header_len)
+            .filter(|header| header.len() >= Ipv4Header::LEN)
+            .ok_or(DecodeError::InvalidValue("IHL"))?;
+        let expected_csum = crate::packet::util::checksum_ipv4_with_skip(header);
         if ipv4.header.header_checksum.get() != expected_csum {
             return Err(DecodeError::InvalidValue("checksum"));
         }
     }
 
     let total_len = usize::from(ipv4.header.total_len.get());
-    if (d.length || d.truncate) && (total_len > buf_len || total_len < Ipv4Header::LEN) {
+    if (d.length || d.truncate)
+        && (total_len > buf_len || total_len < header_len.max(Ipv4Header::LEN))
+    {
         return Err(DecodeError::InvalidValue("total_len"));
     }
 
@@ -522,7 +530,7 @@ impl Debug for Ipv4Header {
 mod tests {
     use zerocopy::{FromBytes, IntoBytes, big_endian};
 
-    use super::{Ipv4, Ipv4Decoder, Ipv4Header, Ipv4PayloadDecoder};
+    use super::{Ipv4, Ipv4Decoder, Ipv4Header, Ipv4Options, Ipv4PayloadDecoder};
     use crate::packet::{DecodeError, Decoder, IpNextProtocol, Udp, UdpDecoder, UdpHeader};
     use std::net::Ipv4Addr;
 
@@ -556,6 +564,50 @@ mod tests {
         0xfe, 0xfd, 0xfc, 0x30, 0x39, 0xff, 0x8d, 0x0, 0x14, 0x6b, 0x0f, 0x48, 0x65, 0x6c, 0x6c,
         0x6f, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x21,
     ];
+
+    const EXAMPLE_IPV4_OPTIONS: &[u8] = &[
+        0x46, 0x0, 0x0, 0x18, 0x0, 0x0, 0x0, 0x0, 0x40, 0x11, 0x8c, 0x9d, 0xc0, 0x0, 0x2, 0x1,
+        0xc6, 0x33, 0x64, 0x2, 0x1, 0x1, 0x0, 0x0,
+    ];
+
+    #[test]
+    fn ipv4_options_are_covered_by_header_checksum() {
+        let decoded: &Ipv4<Ipv4Options> = Ipv4Decoder::CHECK_ALL
+            .decode_ref(EXAMPLE_IPV4_OPTIONS)
+            .expect("IPv4 packet with valid options is valid");
+        assert_eq!(&decoded.payload.options_and_payload, &[1, 1, 0, 0]);
+
+        let mut corrupted = EXAMPLE_IPV4_OPTIONS.to_vec();
+        corrupted[Ipv4Header::LEN] ^= 1;
+        let result: Result<&Ipv4<Ipv4Options>, _> =
+            Ipv4Decoder::CHECK_ALL.decode_ref(&corrupted[..]);
+        assert!(matches!(result, Err(DecodeError::InvalidValue("checksum"))));
+    }
+
+    #[test]
+    fn ipv4_checksum_rejects_truncated_options() {
+        let mut bytes = EXAMPLE_IPV4_OPTIONS.to_vec();
+        bytes.truncate(Ipv4Header::LEN);
+
+        let result: Result<&Ipv4<Ipv4Options>, _> = Ipv4Decoder::CHECK_ALL.decode_ref(&bytes[..]);
+        assert!(matches!(result, Err(DecodeError::InvalidValue("IHL"))));
+    }
+
+    #[test]
+    fn ipv4_total_length_must_cover_options() {
+        let mut bytes = EXAMPLE_IPV4_OPTIONS.to_vec();
+        bytes[2..4].copy_from_slice(&(Ipv4Header::LEN as u16).to_be_bytes());
+
+        let decoder = Ipv4Decoder {
+            checksum: false,
+            ..Ipv4Decoder::CHECK_ALL
+        };
+        let result: Result<&Ipv4<Ipv4Options>, _> = decoder.decode_ref(&bytes[..]);
+        assert!(matches!(
+            result,
+            Err(DecodeError::InvalidValue("total_len"))
+        ));
+    }
 
     /// Test that [`decode_ref`] can decode a valid IPv4/UDP packet.
     #[test]


### PR DESCRIPTION
## summary
- validate IPv4 checksums across the full IHL-declared header
- reject total lengths that end before IPv4 options
- add regression coverage for valid, corrupted and truncated option headers

`Ipv4Decoder` previously calculated the checksum from the fixed 20-byte header, so valid packets with options were rejected. It could also accept a `total_len` shorter than the header declared by IHL

The decoder now slices the complete header safely before calculating its checksum and uses the declared header length for total-length validation

## tests
- `cargo fmt --all -- --check`
- `RUSTFLAGS='--deny warnings' cargo clippy --locked --workspace --all-targets --all-features`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --no-default-features --features ring`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --all-features`
- `RUSTFLAGS='--deny warnings' cargo hack check --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `RUSTDOCFLAGS='--deny warnings' cargo hack doc --locked -p gotatun --each-feature --features aws-lc-rs`
- `cargo shear`
- `cargo semver-checks --workspace --exclude gotatun-cli`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/179)
<!-- Reviewable:end -->
