### PR TITLE
Reject oversized reassembled IPv4 packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Keep IPv4 fragments for different protocols in separate reassembly buffers.
+- Reject fragmented IPv4 packets that exceed the maximum packet length after reassembly.
 - Send persistent keepalive immediately on peer activation, instead of waiting for one full
   interval. This matches wireguard-go and Linux kernel wireguard.
 

--- a/gotatun/src/tun/channel.rs
+++ b/gotatun/src/tun/channel.rs
@@ -181,10 +181,10 @@ mod fragmentation {
             debug_assert!(more_fragments || fragment_offset != 0);
 
             // All fragments except the last must have a length that is a multiple of 8
-            // bytes, and the last fragment must not exceed the maximum IPv4 length.
+            // bytes, and the reassembled packet must not exceed the maximum IPv4 length.
             let fragment_len = ipv4_packet.payload.len();
             if (more_fragments && fragment_len % 8 != 0)
-                || fragment_len + fragment_offset as usize * 8 > Ipv4::MAX_LEN
+                || fragment_len + usize::from(fragment_offset) * 8 > Ipv4::MAX_LEN - Ipv4Header::LEN
             {
                 tracing::trace!(
                     "Invalid fragment size: {fragment_len} or fragment offset: {fragment_offset}, dropping"
@@ -589,6 +589,41 @@ mod fragmentation {
                 0,
                 "All fragments should be processed"
             );
+        }
+
+        #[test]
+        fn test_reassembled_ipv4_packet_length_limit() {
+            const FRAGMENT_PAYLOAD_LEN: usize = 1480;
+
+            let mut fragments = Ipv4Fragments::default();
+            let src = Ipv4Addr::new(192, 0, 2, 1);
+            let dst = Ipv4Addr::new(192, 0, 2, 2);
+            let max_payload_len = Ipv4::MAX_LEN - Ipv4Header::LEN;
+            let fragment_payload = vec![0; FRAGMENT_PAYLOAD_LEN];
+            let full_fragment_count = max_payload_len / FRAGMENT_PAYLOAD_LEN;
+            let last_offset =
+                u16::try_from(full_fragment_count * FRAGMENT_PAYLOAD_LEN / 8).unwrap();
+            let insert_full_fragments = |fragments: &mut Ipv4Fragments, id| {
+                for i in 0..full_fragment_count {
+                    let offset = u16::try_from(i * FRAGMENT_PAYLOAD_LEN / 8).unwrap();
+                    let fragment = make_ip_fragment(id, src, dst, offset, true, &fragment_payload);
+                    assert!(fragments.assemble_ipv4_fragment(fragment).is_none());
+                }
+            };
+
+            insert_full_fragments(&mut fragments, 42);
+            let last_payload = vec![0; max_payload_len % FRAGMENT_PAYLOAD_LEN];
+            let last = make_ip_fragment(42, src, dst, last_offset, false, &last_payload);
+            let packet = fragments
+                .assemble_ipv4_fragment(last)
+                .expect("Maximum-size IPv4 packet should be reassembled");
+            assert_eq!(packet.as_bytes().len(), Ipv4::MAX_LEN);
+
+            insert_full_fragments(&mut fragments, 43);
+            let oversized_last_payload = vec![0; last_payload.len() + 1];
+            let oversized_last =
+                make_ip_fragment(43, src, dst, last_offset, false, &oversized_last_payload);
+            assert!(fragments.assemble_ipv4_fragment(oversized_last).is_none());
         }
 
         #[test]


### PR DESCRIPTION
## summary
- include the IPv4 header in the reassembled packet length limit
- reject fragment sets whose payload would push the packet past 65,535 bytes
- cover the exact maximum and the first invalid length with 1,500-byte fragments

IPv4's 65,535-byte maximum includes its header, but the existing guard applied that limit to the reassembled payload alone. A 65,516-byte payload could reach reassembly, wrap `total_len` to zero and either panic in debug builds or produce a malformed packet in release builds

## tests
- `cargo fmt --check`
- `RUSTFLAGS='--deny warnings' cargo clippy --locked --workspace --all-targets --all-features -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --no-default-features --features ring -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --all-features -j 2`
- `cargo test --release -j 2 -p gotatun --lib test_reassembled_ipv4_packet_length_limit`
- `RUSTFLAGS='--deny warnings' cargo hack check -j 2 --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `RUSTDOCFLAGS='--deny warnings' cargo hack doc -j 2 --locked -p gotatun --each-feature --features aws-lc-rs`
- `cargo shear`
- `cargo semver-checks check-release --workspace --exclude gotatun-cli`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/180)
<!-- Reviewable:end -->
