### PR TITLE
Reject invalid base64 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind only a single dual-stack socket in UdpSocketFactory, instead of a pair of sockets.
 
 ### Fixed
+- Reject malformed base64 keys instead of accepting them as all-zero keys.
 - Validate IPv4 checksums and total lengths against the full IHL-declared header.
 - Keep IPv4 fragments for different protocols in separate reassembly buffers.
 - Reject fragmented IPv4 packets that exceed the maximum packet length after reassembly.

--- a/gotatun/src/serialization.rs
+++ b/gotatun/src/serialization.rs
@@ -10,7 +10,10 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use base64::{Engine as _, prelude::BASE64_STANDARD};
+use base64::{
+    Engine as _,
+    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
+};
 
 pub struct KeyBytes(pub [u8; 32]);
 
@@ -31,13 +34,17 @@ impl std::str::FromStr for KeyBytes {
             }
             43 | 44 => {
                 // Try to parse as base64
-                if let Ok(decoded_key) = BASE64_STANDARD.decode(s) {
-                    if decoded_key.len() == internal.len() {
-                        internal[..].copy_from_slice(&decoded_key);
-                    } else {
-                        return Err("Illegal character in key");
-                    }
+                let decoded_key = if s.len() == 43 {
+                    STANDARD_NO_PAD.decode(s)
+                } else {
+                    STANDARD.decode(s)
                 }
+                .map_err(|_| "Illegal character in key")?;
+
+                if decoded_key.len() != internal.len() {
+                    return Err("Illegal character in key");
+                }
+                internal.copy_from_slice(&decoded_key);
             }
             _ => return Err("Illegal key size"),
         }
@@ -55,5 +62,32 @@ impl std::fmt::Debug for KeyBytes {
 impl From<[u8; 32]> for KeyBytes {
     fn from(bytes: [u8; 32]) -> Self {
         KeyBytes(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeyBytes;
+
+    const KEY: [u8; 32] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31,
+    ];
+
+    #[test]
+    fn parse_padded_and_unpadded_base64_keys() {
+        for encoded in [
+            "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+            "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+        ] {
+            assert_eq!(encoded.parse::<KeyBytes>().unwrap().0, KEY);
+        }
+    }
+
+    #[test]
+    fn reject_invalid_base64_keys() {
+        for invalid in ["!".repeat(43), "!".repeat(44), "A".repeat(44)] {
+            assert!(invalid.parse::<KeyBytes>().is_err());
+        }
     }
 }


### PR DESCRIPTION
## summary
- decode 43-character keys without padding and 44-character keys with canonical padding
- propagate base64 decode failures instead of returning a zero-filled key
- cover padded, unpadded, malformed and wrong-size inputs

`KeyBytes::from_str` ignored base64 decode failures after the move to base64 0.22. This made valid 43-character unpadded keys and malformed 43/44-character inputs parse as 32 zero bytes

The same parser handles UAPI private, public and preshared keys, so malformed input could configure a different key or be interpreted as clearing a PSK

## tests
- `cargo fmt --all -- --check`
- `RUSTFLAGS='--deny warnings' cargo clippy --locked --workspace --all-targets --all-features -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --no-default-features --features ring -j 2`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --all-features -j 2`
- `RUSTFLAGS='--deny warnings' cargo hack check -j 2 --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `RUSTDOCFLAGS='--deny warnings' cargo hack doc -j 2 --locked -p gotatun --each-feature --features aws-lc-rs`
- `cargo shear`
- `cargo semver-checks check-release --workspace --exclude gotatun-cli`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/181)
<!-- Reviewable:end -->
