### PR TITLE
Reject duplicate peer public keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Reject IPv4 fragment sets containing data beyond a terminal fragment.
+- Reject duplicate peer public keys in device builders, batch additions, and UAPI requests.
 
 
 ## [0.8.2] - 2026-08-26

--- a/gotatun/src/device/builder.rs
+++ b/gotatun/src/device/builder.rs
@@ -9,7 +9,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use tokio::sync::{Mutex, RwLock, watch};
 use x25519_dalek::StaticSecret;
@@ -264,9 +264,12 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
     ///
     /// # Errors
     ///
+    /// Errors if multiple peers have the same public key.
     /// Errors if the UDP socket cannot be bound.
     #[cfg_attr(feature = "daita", doc = "Errors if DAITA initialization fails.")]
     pub async fn build(self) -> Result<Device<(Udp, TunTx, TunRx)>, Error> {
+        validate_peers(&self.peers)?;
+
         #[cfg(target_os = "linux")]
         let fwmark = self.fwmark;
         #[cfg(not(target_os = "linux"))]
@@ -316,5 +319,33 @@ impl<Udp: UdpTransportFactory, TunTx: IpSend, TunRx: IpRecv> DeviceBuilder<Udp, 
         }
 
         Ok(Device { inner, fatal_error })
+    }
+}
+
+fn validate_peers(peers: &[Peer]) -> Result<(), Error> {
+    let mut public_keys = HashSet::with_capacity(peers.len());
+    let has_duplicate = peers
+        .iter()
+        .any(|peer| !public_keys.insert(peer.public_key));
+
+    if has_duplicate {
+        Err(Error::DuplicatePeer)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_peers;
+    use crate::device::{Error, Peer};
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    #[test]
+    fn detects_duplicate_peer_public_keys() {
+        let public_key = PublicKey::from(&StaticSecret::random());
+        let peers = [Peer::new(public_key), Peer::new(public_key)];
+
+        assert!(matches!(validate_peers(&peers), Err(Error::DuplicatePeer)));
     }
 }

--- a/gotatun/src/device/configure.rs
+++ b/gotatun/src/device/configure.rs
@@ -10,7 +10,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Configuration and inspection interface for WireGuard devices.
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use ipnetwork::IpNetwork;
 use x25519_dalek::{PublicKey, StaticSecret};
@@ -226,15 +226,16 @@ impl<T: DeviceTransports> DeviceWrite<'_, T> {
 
     /// Add multiple new peers to this [`Device`].
     ///
-    /// If _any_ new peer has the same public key as an existing peer, no new peers are added
-    /// and this function returns `false`. See also [`Self::add_or_update_peers`].
+    /// If _any_ new peer has the same public key as an existing peer or another peer in the batch,
+    /// no new peers are added and this function returns `false`. See also
+    /// [`Self::add_or_update_peers`].
     pub fn add_peers(&mut self, peers: impl IntoIterator<Item = Peer>) -> bool {
         let peers: Vec<_> = peers.into_iter().collect();
+        let mut public_keys = HashSet::with_capacity(peers.len());
 
-        if peers
-            .iter()
-            .any(|peer| self.device.peers.contains_key(&peer.public_key))
-        {
+        if peers.iter().any(|peer| {
+            !public_keys.insert(peer.public_key) || self.device.peers.contains_key(&peer.public_key)
+        }) {
             return false;
         }
 
@@ -510,8 +511,9 @@ impl<T: DeviceTransports> Device<T> {
 
     /// Add multiple new peers to this [`Device`].
     ///
-    /// If _any_ new peer has the same public key as an existing peer, no new peers are added
-    /// and this function returns `false`. See also [`Self::add_or_update_peers`].
+    /// If _any_ new peer has the same public key as an existing peer or another peer in the batch,
+    /// no new peers are added and this function returns `false`. See also
+    /// [`Self::add_or_update_peers`].
     pub async fn add_peers(&self, peers: impl IntoIterator<Item = Peer>) -> Result<bool, Error> {
         self.write(async |device| device.add_peers(peers)).await
     }

--- a/gotatun/src/device/mod.rs
+++ b/gotatun/src/device/mod.rs
@@ -68,6 +68,10 @@ const MAX_PACKET_BUFS: usize = 4000;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+    /// Multiple peers have the same public key
+    #[error("Multiple peers have the same public key")]
+    DuplicatePeer,
+
     /// I/O error
     #[error("i/o error: {0}")]
     IoError(#[from] io::Error),

--- a/gotatun/src/device/tests.rs
+++ b/gotatun/src/device/tests.rs
@@ -183,6 +183,47 @@ async fn test_endpoint_roaming() {
     ping_pong("1.2.3.4".parse().unwrap()).await;
 }
 
+/// Adding peers is atomic, including when a public key is duplicated within the batch.
+#[tokio::test]
+#[test_log::test]
+async fn add_peers_rejects_duplicate_public_keys() {
+    use crate::device::Peer;
+    use ipnetwork::Ipv4Network;
+    use std::{net::Ipv4Addr, sync::Arc};
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    let (_alice, bob, _eve) = mock::device_pair().await;
+    let initial_peers = bob.device.peers().await.len();
+    let public_key = PublicKey::from(&StaticSecret::random());
+    let peer_a = Peer::new(public_key).with_allowed_ip(
+        Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 1), 32)
+            .unwrap()
+            .into(),
+    );
+    let peer_b = Peer::new(public_key).with_allowed_ip(
+        Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 2), 32)
+            .unwrap()
+            .into(),
+    );
+
+    let added = bob
+        .device
+        .add_peers([peer_a, peer_b])
+        .await
+        .expect("device reconfiguration should not fail");
+
+    assert!(!added, "duplicate public keys must reject the entire batch");
+    assert_eq!(bob.device.peers().await.len(), initial_peers);
+
+    let state = bob.device.inner.read().await;
+    assert!(state.peers_by_ip.iter().all(|(routed_peer, _)| {
+        state
+            .peers
+            .values()
+            .any(|peer| Arc::ptr_eq(peer, routed_peer))
+    }));
+}
+
 /// A peer must not inject a packet whose inner source IP belongs
 /// (by longest-prefix match) to a *different* peer, even when the
 /// sending peer's own allowed-ips would cover it. The most specific

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -45,6 +45,7 @@ use eyre::{Context, bail, eyre};
 use libc::EINVAL;
 #[cfg(unix)]
 use nix::unistd::{Gid, Uid};
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::str::FromStr;
@@ -552,21 +553,18 @@ async fn on_api_set(
     set: Set,
     device: &mut DeviceState<impl DeviceTransports>,
 ) -> (SetResponse, Reconfigure) {
+    if let Err(errno) = validate_set(&set) {
+        return (SetResponse { errno }, Reconfigure::No);
+    }
+
     let Set {
         private_key,
         listen_port,
         fwmark,
         replace_peers,
-        protocol_version,
+        protocol_version: _,
         peers,
     } = set;
-
-    if let Some(protocol_version) = protocol_version
-        && protocol_version != "1"
-    {
-        tracing::warn!("Invalid API protocol version: {protocol_version}");
-        return (SetResponse { errno: EINVAL }, Reconfigure::No);
-    }
 
     let mut reconfigure: Reconfigure = Reconfigure::No;
 
@@ -701,6 +699,44 @@ async fn on_api_set(
     }
 
     (SetResponse { errno: 0 }, reconfigure)
+}
+
+fn validate_set(set: &Set) -> Result<(), i32> {
+    if let Some(protocol_version) = &set.protocol_version
+        && protocol_version != "1"
+    {
+        tracing::warn!("Invalid API protocol version: {protocol_version}");
+        return Err(EINVAL);
+    }
+
+    let mut public_keys = HashSet::with_capacity(set.peers.len());
+    if set
+        .peers
+        .iter()
+        .any(|peer| !public_keys.insert(peer.peer.public_key.0))
+    {
+        tracing::warn!("A peer public key was specified more than once");
+        return Err(EINVAL);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EINVAL, validate_set};
+    use crate::{device::uapi::command::SetPeer, serialization::KeyBytes};
+
+    #[test]
+    fn rejects_duplicate_peer_public_keys() {
+        let public_key = KeyBytes([1; 32]);
+        let set = super::Set {
+            peers: vec![SetPeer::new(public_key.0), SetPeer::new(public_key.0)],
+            ..Default::default()
+        };
+
+        assert_eq!(validate_set(&set), Err(EINVAL));
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## summary
- reject duplicate public keys before mutating a peer batch
- return a builder error instead of creating inconsistent peer and route tables
- reject repeated UAPI peer keys with `EINVAL`, as required by the WireGuard configuration protocol
- cover the builder, UAPI and direct device validation paths

`DeviceWrite::add_peers` only checked input keys against peers already on the device. Two entries with the same new key could both reach `DeviceState::add_peer`, where the second entry replaced the main peer map value while routes from the first could still reference its old peer state

The builder could create the same state, and the UAPI accepted repeated public keys even though the protocol forbids them within one message. All three paths now validate the full input before changing device state

## tests
- `cargo fmt --all -- --check`
- `RUSTFLAGS='--deny warnings' cargo clippy --locked --workspace --all-targets --all-features`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --no-default-features --features ring`
- `RUSTFLAGS='--deny warnings' cargo test --locked --workspace --all-features`
- `RUSTFLAGS='--deny warnings' cargo hack check --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `RUSTDOCFLAGS='--deny warnings' cargo hack doc --locked -p gotatun --each-feature --features aws-lc-rs`
- `cargo shear`
- `cargo semver-checks check-release --workspace --exclude gotatun-cli`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/183)
<!-- Reviewable:end -->
