### PR TITLE
Reject IPv4 fragments after terminal fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Reject IPv4 fragment sets containing data beyond a terminal fragment.
+
 
 ## [0.9.0] - 2026-08-18
 ### Added

--- a/gotatun/src/tun/channel.rs
+++ b/gotatun/src/tun/channel.rs
@@ -145,7 +145,8 @@ mod fragmentation {
         // The `VecDeque` is holds the fragments for each unique packet being assembled.
         // It is also a FIFO queue, so that the oldest fragments are dropped when the maximum
         // number of fragments is reached. The inner `Vec` is used to store the fragments.
-        // INVARIANT: The inner `Vec` must always be sorted by fragment_offset
+        // INVARIANT: The inner `Vec` must always be sorted by fragment_offset, and only its
+        // last fragment may have the more-fragments flag unset.
         fragments: VecDeque<(FragmentId, Vec<Packet<Ipv4>>)>,
     }
 
@@ -221,6 +222,21 @@ mod fragmentation {
                 );
                 return None;
             };
+
+            if let Some(prev_i) = i.checked_sub(1)
+                && !fragments[prev_i].header.more_fragments()
+            {
+                tracing::trace!(
+                    "Fragment with offset {fragment_offset} follows a terminal fragment for ID {id:?}, dropping",
+                );
+                return None;
+            }
+            if !more_fragments && fragments.get(i).is_some() {
+                tracing::trace!(
+                    "Terminal fragment with offset {fragment_offset} precedes another fragment for ID {id:?}, dropping",
+                );
+                return None;
+            }
 
             // Check if the new fragment overlaps with existing fragments.
             // Note that the fragments are sorted by fragment_offset, so we only need to check
@@ -720,6 +736,46 @@ mod fragmentation {
                     "First fragment should be dropped because it overlaps with the second"
                 );
             }
+        }
+
+        #[test]
+        fn test_fragment_after_terminal_fragment_is_dropped() {
+            let mut fragments = Ipv4Fragments::default();
+            let src = Ipv4Addr::new(192, 0, 2, 1);
+            let dst = Ipv4Addr::new(192, 0, 2, 2);
+            let id = 42;
+
+            let terminal = make_ip_fragment(id, src, dst, 1, false, b"terminal");
+            let conflicting = make_ip_fragment(id, src, dst, 2, false, b"conflict");
+            let first = make_ip_fragment(id, src, dst, 0, true, b"first___");
+
+            assert!(fragments.assemble_ipv4_fragment(terminal).is_none());
+            assert!(fragments.assemble_ipv4_fragment(conflicting).is_none());
+
+            let packet = fragments
+                .assemble_ipv4_fragment(first)
+                .expect("fragments up to the first terminal fragment should reassemble");
+            assert_eq!(packet.payload, *b"first___terminal");
+        }
+
+        #[test]
+        fn test_terminal_fragment_before_buffered_fragment_is_dropped() {
+            let mut fragments = Ipv4Fragments::default();
+            let src = Ipv4Addr::new(192, 0, 2, 1);
+            let dst = Ipv4Addr::new(192, 0, 2, 2);
+            let id = 42;
+
+            let later = make_ip_fragment(id, src, dst, 2, false, b"later___");
+            let conflicting_terminal = make_ip_fragment(id, src, dst, 1, false, b"terminal");
+            let first = make_ip_fragment(id, src, dst, 0, true, b"first___");
+
+            assert!(fragments.assemble_ipv4_fragment(later).is_none());
+            assert!(
+                fragments
+                    .assemble_ipv4_fragment(conflicting_terminal)
+                    .is_none()
+            );
+            assert!(fragments.assemble_ipv4_fragment(first).is_none());
         }
     }
 }


### PR DESCRIPTION
## summary
- keep the first terminal IPv4 fragment as the end of the reassembled datagram
- reject fragments at higher offsets and conflicting terminal fragments at lower offsets
- cover both arrival orders with adjacent, non-overlapping fragments

The reassembler only checked that the highest-offset buffered fragment had the more-fragments flag unset. Two terminal fragments could therefore be treated as consecutive and bytes beyond the first declared end could be emitted

The new checks preserve the existing first-wins behavior used for duplicate and overlapping fragments while ensuring that only the highest-offset buffered fragment can be terminal

## tests
- `cargo fmt --check`
- `RUSTFLAGS='--deny warnings' cargo clippy -j2 --locked --workspace --all-targets --all-features`
- `RUSTFLAGS='--deny warnings' cargo test -j2 --locked --workspace`
- `RUSTFLAGS='--deny warnings' cargo test -j2 --locked --workspace --no-default-features --features ring`
- `RUSTFLAGS='--deny warnings' cargo test -j2 --locked --workspace --all-features`
- `RUSTFLAGS='--deny warnings' cargo hack check -j2 --locked --workspace --feature-powerset --at-least-one-of ring,aws-lc-rs --mutually-exclusive-features ring,aws-lc-rs --exclude-features default`
- `RUSTDOCFLAGS='--deny warnings' cargo hack doc -j2 --locked -p gotatun --each-feature --features aws-lc-rs`
- `cargo shear`
- `cargo semver-checks --workspace --exclude gotatun-cli`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/185)
<!-- Reviewable:end -->
