### PR TITLE
Add `nix-build.yml` workflow for building `gotatun-cli` with nix

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,27 @@
+name: nix / Build (Linux)
+on:
+  pull_request:
+    paths:
+      - .github/workflows/nix-build.yml
+      - rust-toolchain.toml
+      - 'flake*'
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
+
+      - name: Build default package
+        run: nix build


### PR DESCRIPTION
Catch regressions to `flake.nix` earlier by excersising the nix build. Follow up to https://github.com/mullvad/gotatun/pull/184.

Example run: https://github.com/mullvad/gotatun/actions/runs/32704818273/job/97363553937?pr=186

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/186)
<!-- Reviewable:end -->
