### PR TITLE
Fix device-only Windows builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,10 @@ jobs:
       - name: Check with features "${{ matrix.features }}"
         run: cargo check --locked --workspace ${{ matrix.features }}
 
+      - name: Check device without tun (Windows)
+        if: matrix.os == 'windows-latest' && matrix.features == ''
+        run: cargo check --locked -p gotatun --no-default-features --features device,ring
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+#### Windows
+- Allow the `device` feature to build without the `tun` feature.
 
 
 ## [0.9.1] - 2026-08-27

--- a/gotatun/src/tun/buffer.rs
+++ b/gotatun/src/tun/buffer.rs
@@ -220,6 +220,7 @@ fn is_fatal_tun_error(err: &io::Error) -> bool {
         }
 
         // TODO: Propagate the underlying error from tun/wintun-bindings and remove this
+        #[cfg(feature = "tun")]
         if let Some(ERROR_HANDLE_EOF) = err
             .get_ref()
             .and_then(|e| e.downcast_ref::<wintun_bindings::Error>())


### PR DESCRIPTION
## summary

- gate the `wintun-bindings` error downcast on the `tun` feature
- add a package-scoped Windows check for `device,ring` without `tun`

`buffer` is compiled by `device`, while `wintun-bindings` is only activated by `tun`. This broke Windows consumers that provide their own device implementation without enabling `tun`

Fixes #190

## tests

- `RUSTFLAGS='--deny warnings' cargo check -j2 --locked -p gotatun --target x86_64-pc-windows-gnu --no-default-features --features device,ring`
- `RUSTFLAGS='--deny warnings' cargo clippy -j2 --locked -p gotatun --target x86_64-pc-windows-gnu --no-default-features --features device,ring -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -j2 --locked --workspace`
- `cargo test -j2 --locked --workspace --no-default-features --features ring`
- `cargo test -j2 --locked --workspace --all-features`
- `cargo clippy -j2 --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo hack check --locked --feature-powerset --exclude-features mocks,test-utils,experimental,default`
- `cargo hack doc --locked --feature-powerset --exclude-features mocks,test-utils,experimental,default`
- `cargo shear`
- `cargo semver-checks --workspace --exclude gotatun-cli`
- `actionlint .github/workflows/test.yml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/191)
<!-- Reviewable:end -->
