### PR TITLE
Apply the dual-stack address mapping outside Apple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Apply the dual-stack address mapping on every target served by the generic UDP
+  socket implementation, not only Apple targets. Sending to an IPv4 peer on a
+  dual-stack socket previously failed with `EAFNOSUPPORT` on those targets, and
+  received datagrams reported an unmapped `::ffff:` source address.
+#### iOS
+- Stop compiling `check_send_max_number_of_packets` on targets that never call it.
 
 
 ## [0.9.2] - 2026-08-31

--- a/gotatun/src/udp/socket/generic.rs
+++ b/gotatun/src/udp/socket/generic.rs
@@ -23,7 +23,6 @@ impl UdpSend for super::UdpSocket {
     type SendManyBuf = ();
 
     async fn send_to(&self, packet: Packet, dest: SocketAddr) -> io::Result<()> {
-        #[cfg(target_vendor = "apple")]
         let dest = self.map_dst(dest);
         self.socket().send_to(&packet, dest).await?;
         Ok(())
@@ -41,7 +40,6 @@ impl UdpRecv for super::UdpSocket {
         let mut buf = pool.get();
         let (n, src) = self.socket().recv_from(&mut buf).await?;
         buf.truncate(n);
-        #[cfg(target_vendor = "apple")]
         let src = self.map_src(src);
         Ok((buf, src))
     }

--- a/gotatun/src/udp/socket/mod.rs
+++ b/gotatun/src/udp/socket/mod.rs
@@ -173,7 +173,7 @@ impl UdpSocket {
     }
 
     /// Map an IPv4 address to IPv6 if necessary.
-    #[cfg(any(target_os = "windows", target_vendor = "apple"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline(always)]
     fn map_dst(&self, mut addr: SocketAddr) -> SocketAddr {
         if self.map_ipv4_to_ipv6
@@ -230,7 +230,7 @@ fn is_ipv6_unavailable(err: &io::Error) -> bool {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 fn check_send_max_number_of_packets(
     max_number_of_packets: usize,
     packets: &[(crate::packet::Packet, SocketAddr)],


### PR DESCRIPTION
The `generic` UDP socket module is selected for
`not(any(target_os = "linux", target_os = "android", target_os = "windows"))`,
which is Apple **and every other target**. Both of its address-mapping calls are
gated on `target_vendor = "apple"`, so a non-Apple target reaching `generic`
gets a dual-stack socket with no address mapping at all.

## What breaks

`UdpSocketFactory::bind` creates a dual-stack socket, and
`device::open_listen_socket` always asks for one. On such a socket an IPv4 peer
must be addressed as `::ffff:a.b.c.d` on send and canonicalized back to
`a.b.c.d` on receive — which `linux`, `windows` and `generic` all implement.
With the mapping skipped, measured on FreeBSD 14.3-RELEASE on a dual-stack
`AF_INET6` UDP socket:

- `sendto` with a `sockaddr_in` destination fails with `EAFNOSUPPORT`. The
  `::ffff:` form that `map_dst` produces is delivered.
- A datagram from an IPv4 peer is reported with source `::ffff:127.0.0.1`,
  which no endpoint comparison against the peer's own address will match.

`dual_stack_socket_send` and `dual_stack_socket_recv` assert the opposite of
both, so neither can pass on such a target.

## Where the gate came from

It is not inherited — it was introduced in 40aced5 ("Use dual-stack IPv6/IPv4
sockets") together with the mapping itself, gating it to the non-Linux/Windows
platforms that change was written for. That `generic` is also the fallback for
every other target is easy to miss.

## What it changes for the platforms you support

Nothing that CI compiles. Across Linux, `x86_64-linux-android`, Windows and
macOS, `generic` is reached by macOS alone, which is `target_vendor = "apple"` —
so removing that gate changes nothing on any of them, and widening `map_dst`'s
gate adds no caller.

The one change on a platform you ship is on **iOS**, which CI does not cover.
`check_send_max_number_of_packets` is gated `not(target_os = "macos")` but is
called only from the `linux` and `windows` modules, so on iOS it is compiled and
never used. Building the published 0.9.2 package for `aarch64-apple-ios`:

```
$ cargo check --target aarch64-apple-ios --no-default-features --features device,ring
warning: function `check_send_max_number_of_packets` is never used
warning: `gotatun` (lib) generated 1 warning
```

With this change the same check is clean.

## The change

Each item's `cfg` is made equal to the set of targets that reference it:

- `generic.rs` — the two mapping calls run on every target the module serves.
- `map_dst` — compiled everywhere except the Linux module, which sends unmapped
  deliberately (`udpv6_sendmsg` hands an `AF_INET` sockaddr on a socket that is
  not `v6only` to the IPv4 path; Apple, Windows and FreeBSD do not extend that).
- `check_send_max_number_of_packets` — compiled for exactly the two modules that
  call it.

## Context

Found while vendoring gotatun for a project that ships FreeBSD, OpenBSD and
NetBSD builds alongside the platforms you support. Happy to reword the changelog
entry, or to split the iOS dead-code half into its own commit, if you prefer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/193)
<!-- Reviewable:end -->
