### PR TITLE
Bind UAPI unix socket without doubled slash in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Bind the UAPI unix socket at `/var/run/wireguard/<name>.sock` without a doubled
+  slash in the path. The kernel previously reported the bound path as
+  `/var/run/wireguard//<name>.sock`, which broke exact-path lookups such as
+  `lsof /var/run/wireguard/<name>.sock`.
 - Apply the dual-stack address mapping on every target served by the generic UDP
   socket implementation, not only Apple targets. Sending to an IPv4 peer on a
   dual-stack socket previously failed with `EAFNOSUPPORT` on those targets, and

--- a/gotatun/src/device/uapi/mod.rs
+++ b/gotatun/src/device/uapi/mod.rs
@@ -56,7 +56,7 @@ use std::time::SystemTime;
 use tokio::sync::{RwLock, mpsc, oneshot};
 
 #[cfg(unix)]
-const SOCK_DIR: &str = "/var/run/wireguard/";
+const SOCK_DIR: &str = "/var/run/wireguard";
 
 /// A server that receives [`Request`]s. Should be passed to [`DeviceBuilder::with_uapi`].
 ///


### PR DESCRIPTION
## Summary

`SOCK_DIR` was defined with a trailing slash and then joined as `format!("{SOCK_DIR}/{name}.sock")`, so the UAPI unix socket was bound at `/var/run/wireguard//<name>.sock`. The kernel reports a bound unix socket path verbatim, so the doubled slash leaks into every consumer that lists sockets:

```
$ sudo lsof -U | grep wireguard
gotatun   62012   root   14u   unix 0x904d...  0t0  /var/run/wireguard//utun4.sock
```

This breaks exact-path lookups of the socket, most visibly `lsof /var/run/wireguard/utun4.sock`, which returns nothing for a live daemon. `wireguard-go` binds the single-slash form, so any tooling written against that convention fails to find gotatun's daemon (see #194, where this broke a `wg-quick down` cleanup helper that resolves the daemon PID via its socket).

Connecting, stat and unlink of the path keep working regardless (the kernel normalizes the path on those operations), which is why the integration tests — which dial `/var/run/wireguard/<name>.sock` — never caught this.

## Changes

- Drop the trailing slash from `SOCK_DIR`; the only format-string use already adds its own `/`, and `create_dir` is unaffected.
- CHANGELOG entry under `Unreleased / Fixed`.

## Verification

- `cargo check -p gotatun` and `cargo check -p gotatun-cli` pass with the pinned toolchain (1.95.0).
- Before/after on macOS (gotatun-cli 0.9.2 + wg-quick): with the fix, `sudo lsof -t /var/run/wireguard/utunN.sock` resolves the daemon PID of a running tunnel, matching wireguard-go behavior.

Fixes the socket-path part of #194.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/gotatun/195)
<!-- Reviewable:end -->
